### PR TITLE
Backfill missing directory READMEs

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,1 +1,5 @@
 This directory contains all files used to build and run the extension.
+
+- [action](./action/README.md): browser action pages, popup flows, and related UI assets.
+- [components](./components/README.md): reusable custom elements shared across popup and settings pages.
+- [settings](./settings/README.md): the extension options page exposed through the manifest.

--- a/src/action/README.md
+++ b/src/action/README.md
@@ -1,1 +1,6 @@
 This directory contains code that will be used by the action in the browser (when clicking the icon related to this extension).
+
+- [popup](./popup/README.md): the default action popup.
+- [logo](./logo/README.md): the shared logo iframe used by action pages.
+- [notSalesforceSetup](./notSalesforceSetup/README.md): the page shown when the active tab is not a Salesforce Setup page.
+- [req_permissions](./req_permissions/README.md): the permission request page used for optional host and downloads permissions.

--- a/src/action/req_permissions/README.md
+++ b/src/action/req_permissions/README.md
@@ -1,0 +1,9 @@
+This directory contains the permission request page used when the popup cannot continue without an optional permission.
+
+Key files:
+
+- `req_permissions.html` renders the shared permission prompt UI for both host access and downloads access.
+- `req_permissions.js` reads the `whichid` query parameter, requests the matching permission, and routes the user back to the normal popup flow.
+- `req_permissions.css` styles the page on top of the shared action styles.
+
+This page is opened from [`src/action/popup/popup.js`](../popup/popup.js) when host permissions are missing, and from [`src/background/utils.js`](../../background/utils.js) when an export needs downloads permission. The `whichid=hostpermissions` flow can also persist a local `DO_NOT_REQUEST_FRAME_PERMISSION` flag when the user asks not to be prompted again.

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -1,1 +1,5 @@
 This directory contains components used elsewhere by the extension; divided into their own folders.
+
+- [help](./help/README.md): the tooltip help icon custom element used by the settings UI and generated Salesforce markup.
+- [review-sponsor](./review-sponsor/README.md): the review and sponsor CTA custom element used by popup and settings pages.
+- [theme-selector](./theme-selector/README.md): the light and dark theme toggle used by popup and settings pages.

--- a/src/components/help/README.md
+++ b/src/components/help/README.md
@@ -1,0 +1,8 @@
+This directory contains the reusable `help-aws` help icon component.
+
+Key files:
+
+- `help.js` defines the custom element, attaches the generated tooltip markup in shadow DOM, and keeps the link and accessible name in sync with host attributes.
+- `help.css` styles the tooltip and is injected both by the component itself and by generated Salesforce help markup.
+
+The settings page loads this component directly from [`src/settings/options.html`](../../settings/options.html). The same styling is also referenced by [`src/salesforce/generator.js`](../../salesforce/generator.js) and exposed in the manifest as a web-accessible resource so generated help popups render consistently on Salesforce pages.

--- a/src/components/review-sponsor/README.md
+++ b/src/components/review-sponsor/README.md
@@ -1,0 +1,8 @@
+This directory contains the reusable `review-sponsor-aws` call-to-action component.
+
+Key files:
+
+- `review-sponsor.js` defines the custom element, decides whether review and sponsor links should be shown, and opens the correct browser-specific or language-specific destination.
+- `review-sponsor.css` styles the SVG-based links inside the component shadow DOM.
+
+This component is loaded by both [`src/action/popup/popup.html`](../../action/popup/popup.html) and [`src/settings/options.html`](../../settings/options.html). Visibility depends on saved tab count from `ensureAllTabsAvailability()` and on `EXTENSION_USAGE_DAYS`, so the links stay hidden until the extension has seen enough usage.

--- a/src/components/theme-selector/README.md
+++ b/src/components/theme-selector/README.md
@@ -1,0 +1,8 @@
+This directory contains the reusable `theme-selector-aws` theme toggle component.
+
+Key files:
+
+- `theme-selector.js` defines the custom element, injects its stylesheet once, tracks the active document theme, and delegates theme switches to `handleSwitchColorTheme`.
+- `theme-selector.css` styles the light and dark toggle buttons and their transition states.
+
+The popup and settings entry scripts both import this module before rendering [`src/action/popup/popup.html`](../../action/popup/popup.html) and [`src/settings/options.html`](../../settings/options.html). The component watches `document.documentElement.dataset.theme` and emits a `before-theme-toggle` event so host pages can prepare their own transitions before the shared theme handler runs.

--- a/src/settings/README.md
+++ b/src/settings/README.md
@@ -1,0 +1,9 @@
+This directory contains the extension settings page exposed through the manifest options UI.
+
+Key files:
+
+- `options.html` defines the settings layout, loads the shared action styles, and mounts the `help-aws`, `review-sponsor-aws`, and `theme-selector-aws` components.
+- `options.js` wires the settings controls to extension storage and messaging, requests optional permissions when needed, and keeps the page theme in sync.
+- `options.css` contains the page-specific styling layered on top of the shared action styles.
+
+This page is loaded from `options_ui.page` in [`src/manifest/template-manifest.json`](../manifest/template-manifest.json), and the popup also opens it through `openSettingsPage` in [`src/functions.js`](../functions.js).


### PR DESCRIPTION
## Summary
- add missing directory README files for settings, req_permissions, and shared component folders
- update the src, action, and components index docs so the new documentation is discoverable
- keep the change docs-only with no runtime code changes

## Validation
- `deno lint`
- `deno test` *(fails in the current branch because the existing test suite does not type-check; examples include `tests/background/background.test.ts` and `tests/components/theme-selector.test.ts`, plus an untracked local `content-listener.test.ts` also fails when running from repo root)*