### PR TITLE
docs: backfill missing directory READMEs

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,1 +1,5 @@
 This directory contains all files used to build and run the extension.
+
+- [action](./action/README.md): browser action pages, popup routing, and permission-request flows.
+- [components](./components/README.md): reusable UI components and shared styling used by extension pages and generated Salesforce markup.
+- [settings](./settings/README.md): the extension options page exposed through the manifest.

--- a/src/action/README.md
+++ b/src/action/README.md
@@ -1,1 +1,6 @@
 This directory contains code that will be used by the action in the browser (when clicking the icon related to this extension).
+
+- [popup](./popup/README.md): the default action popup.
+- [logo](./logo/README.md): the shared logo iframe used by action pages.
+- [notSalesforceSetup](./notSalesforceSetup/README.md): the page shown when the active tab is not a Salesforce Setup page.
+- [req_permissions](./req_permissions/README.md): the permission request page used for optional Salesforce host and downloads permissions.

--- a/src/action/req_permissions/README.md
+++ b/src/action/req_permissions/README.md
@@ -1,0 +1,9 @@
+This directory contains the permission request page used when the popup or export flow cannot continue without an optional permission.
+
+Key files:
+
+- `req_permissions.html` renders the shared permission prompt UI for both Salesforce host access and downloads access.
+- `req_permissions.js` reads the `whichid` query parameter, requests the matching permission, and routes the user back to the normal popup flow.
+- `req_permissions.css` styles the page on top of the shared action styles.
+
+This page is opened from [`src/action/popup/popup.js`](../popup/popup.js) when Salesforce host permissions are missing, and from [`src/background/utils.js`](../../background/utils.js) when an export needs downloads permission. The `whichid=hostpermissions` flow can also persist `DO_NOT_REQUEST_FRAME_PERMISSION` in local storage when the user asks not to be prompted again.

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -1,1 +1,5 @@
 This directory contains components used elsewhere by the extension; divided into their own folders.
+
+- [help](./help/README.md): the tooltip help icon custom element and shared stylesheet used by the settings UI and generated Salesforce help markup.
+- [review-sponsor](./review-sponsor/README.md): the review and sponsor CTA custom element used by popup and settings pages.
+- [theme-selector](./theme-selector/README.md): the theme toggle custom element imported by popup and settings entry scripts.

--- a/src/components/help/README.md
+++ b/src/components/help/README.md
@@ -1,0 +1,8 @@
+This directory contains the reusable `help-aws` help icon component.
+
+Key files:
+
+- `help.js` defines the custom element, attaches generated tooltip markup in shadow DOM, and keeps the link target plus accessible name in sync with host attributes.
+- `help.css` styles the tooltip and is injected both by the component itself and by generated Salesforce help markup.
+
+The settings page loads this component directly from [`src/settings/options.html`](../../settings/options.html). The same stylesheet is also referenced by [`src/salesforce/generator.js`](../../salesforce/generator.js) and exposed in the manifest as a web-accessible resource so generated help popups render consistently on Salesforce pages.

--- a/src/components/review-sponsor/README.md
+++ b/src/components/review-sponsor/README.md
@@ -1,0 +1,8 @@
+This directory contains the reusable `review-sponsor-aws` call-to-action component.
+
+Key files:
+
+- `review-sponsor.js` defines the custom element, decides whether review and sponsor links should be shown, and opens the correct browser-specific or language-specific destination.
+- `review-sponsor.css` styles the SVG-based links inside the component shadow DOM and matches the page-level stylesheet loaded by popup and settings HTML.
+
+This component is loaded by both [`src/action/popup/popup.html`](../../action/popup/popup.html) and [`src/settings/options.html`](../../settings/options.html). Visibility depends on saved tab count from `ensureAllTabsAvailability()` and on `EXTENSION_USAGE_DAYS`, so the links stay hidden until the extension has seen enough usage.

--- a/src/components/theme-selector/README.md
+++ b/src/components/theme-selector/README.md
@@ -1,0 +1,8 @@
+This directory contains the reusable `theme-selector-aws` theme toggle component.
+
+Key files:
+
+- `theme-selector.js` defines the custom element, injects its stylesheet once, tracks the active document theme, and delegates theme switches to `handleSwitchColorTheme`.
+- `theme-selector.css` styles the light and dark toggle buttons plus their transition states.
+
+The popup and settings entry scripts import this module before rendering [`src/action/popup/popup.html`](../../action/popup/popup.html) and [`src/settings/options.html`](../../settings/options.html). The component watches `document.documentElement.dataset.theme` and emits a `before-theme-toggle` event so host pages can prepare their own transitions before the shared theme handler runs.

--- a/src/settings/README.md
+++ b/src/settings/README.md
@@ -1,0 +1,9 @@
+This directory contains the extension settings page exposed through the manifest `options_ui`.
+
+Key files:
+
+- `options.html` defines the settings layout, loads the shared action styles, registers the `help-aws` and `review-sponsor-aws` components, and mounts `theme-selector-aws`.
+- `options.js` wires the controls to extension storage and messaging, requests optional permissions when needed, imports `theme-selector-aws`, and coordinates page theme transitions.
+- `options.css` contains the page-specific styling layered on top of the shared action styles.
+
+This page is loaded from `options_ui.page` in [`src/manifest/template-manifest.json`](../manifest/template-manifest.json), and extension flows open it through `openSettingsPage` in [`src/functions.js`](../functions.js).


### PR DESCRIPTION
## Summary
- add missing directory READMEs for settings, permission requests, and reusable component folders
- update the src, action, and components index docs so the new documentation is discoverable
- correct the components index description so it reflects usage in generated Salesforce markup as well as extension pages

## Validation
- deno lint
- deno test *(fails due pre-existing TypeScript errors across the existing test suite; no docs-related regressions identified)*


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: docs-backfill:/home/alfredo/gitRepos/again-why-salesforce
task-type: docs-backfill
task-title: Documentation Backfiller
provider: codex
score: 3.0
cost-tier: Low (10-50k)
branch: stag
iterations: 2
duration: 16m34s
run-started: 2026-03-16T21:00:00+01:00
nightshift:metadata -->
