### PR TITLE
Add setup knowledge silo detector

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -711,6 +711,10 @@
 		"message": "Pins your saved $tabs before the standard navigation menu (Home / Object Manager) in Setup, instead of after it.",
 		"description": "[settings-help] for $opt_keep_tabs_left"
 	},
+	"help_knowledge_silo_detection": {
+		"message": "Checks visible Setup list pages for Owner, Created By, or Last Modified By columns and warns when one person dominates the visible records.",
+		"description": "[settings-help] for $opt_knowledge_silo_detection"
+	},
 	"help_link_new_browser": {
 		"message": "When enabled, every saved $tab will open the related page in a new $tab",
 		"description": "[settings-help] for $opt_link_new_browser"
@@ -911,6 +915,18 @@
 		"message": "Opportunity",
 		"description": "The page related to ObjectManager/Opportunity/FieldsAndRelationships/view"
 	},
+	"knowledge_silo_dominates": {
+		"message": "dominates",
+		"description": "[knowledge-silo-toast] indicates one visible contributor controls most listed rows"
+	},
+	"knowledge_silo_visible_rows_in": {
+		"message": "visible rows in",
+		"description": "[knowledge-silo-toast] introduces the column used by the silo heuristic"
+	},
+	"knowledge_silo_warning": {
+		"message": "Potential knowledge silo:",
+		"description": "[knowledge-silo-toast] warning prefix when one visible contributor dominates a setup list page"
+	},
 	"opt_add_tabs_as_org": {
 		"message": "Add new $tabs as $org_tabs",
 		"description": "[settings] let the user add all new $tabs as $org-specific"
@@ -950,6 +966,10 @@
 	"opt_keep_tabs_left": {
 		"message": "Keep favourite $tabs on the left of Home and Object Manager.",
 		"description": "Toggle to pin favorite $tabs to the left side of the navigation bar"
+	},
+	"opt_knowledge_silo_detection": {
+		"message": "Warn when one person dominates the visible setup records.",
+		"description": "[setting] opt in to client-side knowledge silo detection on eligible setup list pages"
 	},
 	"opt_link_new_browser": {
 		"message": "Always open links in a new browser $tab",

--- a/src/constants.js
+++ b/src/constants.js
@@ -93,6 +93,7 @@ export const TAB_AS_ORG = "tab_as_org";
 export const NO_RELEASE_NOTES = "no_release_notes";
 export const NO_UPDATE_NOTIFICATION = "no_update_notification";
 export const PREVENT_ANALYTICS = "prevent_analytics";
+export const KNOWLEDGE_SILO_DETECTION = "knowledge_silo_detection";
 export const PERSIST_SORT = "persist_sort";
 export const EXTENSION_USAGE_DAYS = "extension_usage_days";
 export const EXTENSION_LAST_ACTIVE_DAY = "extension_last_active_day";

--- a/src/salesforce/content.js
+++ b/src/salesforce/content.js
@@ -29,6 +29,7 @@ import {
 	EXTENSION_NAME,
 	HAS_ORG_TAB,
 	HTTPS,
+	KNOWLEDGE_SILO_DETECTION,
 	LIGHTNING_FORCE_COM,
 	LINK_NEW_BROWSER,
 	SALESFORCE_URL_PATTERN,
@@ -84,6 +85,7 @@ import { createExportModal } from "./export.js";
 import { createManageTabsModal } from "./manageTabs.js";
 import { checkTutorial, startTutorial } from "./tutorial.js";
 import { executeOncePerDay } from "./once-a-day.js";
+import { detectKnowledgeSilo } from "./knowledge-silo.js";
 
 /**
  * The main UL on Salesforce Setup
@@ -382,6 +384,49 @@ function onHrefUpdate() {
 	}
 	href = newRef;
 	isOnSavedTab(true, _afterHrefUpdate);
+	maybeShowKnowledgeSiloWarning();
+}
+
+/**
+ * Returns whether the knowledge silo detector is enabled in settings.
+ *
+ * @return {Promise<boolean>} `true` when the detector should run.
+ */
+async function isKnowledgeSiloDetectionEnabled() {
+	const setting = await getSettings(KNOWLEDGE_SILO_DETECTION);
+	if (Array.isArray(setting)) {
+		return setting.some((item) => item?.enabled);
+	}
+	return setting?.enabled === true;
+}
+
+/**
+ * Runs the knowledge silo detector and surfaces warnings through the toast UI.
+ *
+ * @return {Promise<void>} Resolves after the detector finishes.
+ */
+async function maybeShowKnowledgeSiloWarning() {
+	if (!getCurrentHref()?.includes(SETUP_LIGHTNING)) {
+		return;
+	}
+	if (!await isKnowledgeSiloDetectionEnabled()) {
+		return;
+	}
+	const result = detectKnowledgeSilo({ href: getCurrentHref() });
+	if (!result.shouldWarn) {
+		return;
+	}
+	showToast(
+		[
+			"knowledge_silo_warning",
+			result.dominantName,
+			"knowledge_silo_dominates",
+			`${result.dominantCount}/${result.sampleSize}`,
+			"knowledge_silo_visible_rows_in",
+			result.columnLabel,
+		],
+		TOAST_WARNING,
+	);
 }
 
 /**
@@ -466,6 +511,7 @@ function delayLoadSetupTabs(count = 0) {
 	setupDragForUl(reorderTabsUl);
 	reloadTabs();
 	checkTutorial();
+	maybeShowKnowledgeSiloWarning();
 }
 
 /**

--- a/src/salesforce/knowledge-silo.js
+++ b/src/salesforce/knowledge-silo.js
@@ -1,0 +1,309 @@
+"use strict";
+
+export const KNOWLEDGE_SILO_MIN_SAMPLE_SIZE = 5;
+export const KNOWLEDGE_SILO_DOMINANCE_THRESHOLD = 0.6;
+
+const ELIGIBLE_COLUMN_LABELS = new Set([
+	"owner",
+	"created by",
+	"last modified by",
+]);
+const WARNING_CACHE = new Set();
+
+/**
+ * Normalizes whitespace and casing for labels extracted from the page.
+ *
+ * @param {string|null|undefined} value Raw value from the DOM.
+ * @return {string} Normalized text.
+ */
+export function normalizeKnowledgeSiloText(value) {
+	return `${value ?? ""}`.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Returns whether the supplied element is currently visible.
+ *
+ * @param {HTMLElement|null} element Element to inspect.
+ * @return {boolean} `true` when the element is visible.
+ */
+export function isVisibleKnowledgeSiloElement(element) {
+	let currentElement = element;
+	while (currentElement != null) {
+		if (
+			currentElement.hidden ||
+			currentElement.ariaHidden === "true" ||
+			currentElement.getAttribute("hidden") != null ||
+			currentElement.style?.display === "none" ||
+			currentElement.style?.visibility === "hidden"
+		) {
+			return false;
+		}
+		currentElement = currentElement.parentElement;
+	}
+	return element != null;
+}
+
+/**
+ * Returns the visible header labels for a table.
+ *
+ * @param {HTMLTableElement} table Table to inspect.
+ * @return {string[]} Visible header labels.
+ */
+export function getKnowledgeSiloHeaderLabels(table) {
+	const headerCells = [...table.querySelectorAll("thead th")];
+	const cells = headerCells.length > 0
+		? headerCells
+		: [...table.querySelectorAll("tr th")];
+	return cells
+		.filter((cell) => isVisibleKnowledgeSiloElement(cell))
+		.map((cell) => normalizeKnowledgeSiloText(cell.textContent));
+}
+
+/**
+ * Finds the first eligible table and column that can be used for silo analysis.
+ *
+ * @param {ParentNode} [root=document] Root node to inspect.
+ * @return {{
+ * 	reason: string;
+ * 	table?: HTMLTableElement;
+ * 	columnIndex?: number;
+ * 	columnLabel?: string;
+ * }} Matching table metadata or a failure reason.
+ */
+export function findKnowledgeSiloTable(root = document) {
+	const tables = [...root.querySelectorAll("table")];
+	if (tables.length === 0) {
+		return { reason: "unsupported-page" };
+	}
+	for (const table of tables) {
+		const headerLabels = getKnowledgeSiloHeaderLabels(table);
+		const columnIndex = headerLabels.findIndex((label) =>
+			ELIGIBLE_COLUMN_LABELS.has(label.toLowerCase())
+		);
+		if (columnIndex >= 0) {
+			return {
+				reason: "eligible-table",
+				table,
+				columnIndex,
+				columnLabel: headerLabels[columnIndex],
+			};
+		}
+	}
+	return { reason: "missing-column" };
+}
+
+/**
+ * Returns the visible data rows for a table.
+ *
+ * @param {HTMLTableElement} table Table to inspect.
+ * @return {HTMLTableRowElement[]} Visible data rows.
+ */
+export function getVisibleKnowledgeSiloRows(table) {
+	const rows = [...table.querySelectorAll("tr")].slice(1);
+	return rows.filter((row) => isVisibleKnowledgeSiloElement(row));
+}
+
+/**
+ * Extracts normalized names from the selected ownership column.
+ *
+ * @param {HTMLTableElement} table Table holding the records.
+ * @param {number} columnIndex Zero-based ownership column index.
+ * @return {string[]} Visible normalized names.
+ */
+export function extractKnowledgeSiloNames(table, columnIndex) {
+	return getVisibleKnowledgeSiloRows(table)
+		.map((row) => {
+			const cells = [...row.children].filter((cell) =>
+				isVisibleKnowledgeSiloElement(cell)
+			);
+			return normalizeKnowledgeSiloText(cells[columnIndex]?.textContent);
+		})
+		.filter(Boolean);
+}
+
+/**
+ * Calculates whether a single visible owner dominates the sampled rows.
+ *
+ * @param {string[]} names Visible owner or author names.
+ * @param {Object} [options={}] Heuristic overrides.
+ * @param {number} [options.minSampleSize=KNOWLEDGE_SILO_MIN_SAMPLE_SIZE] Minimum sample size.
+ * @param {number} [options.dominanceThreshold=KNOWLEDGE_SILO_DOMINANCE_THRESHOLD] Minimum ratio for a warning.
+ * @return {{
+ * 	reason: string;
+ * 	dominantCount: number;
+ * 	dominantName: string|null;
+ * 	dominanceRatio: number;
+ * 	sampleSize: number;
+ * 	shouldWarn: boolean;
+ * }} Heuristic result.
+ */
+export function analyzeKnowledgeSiloNames(names, {
+	minSampleSize = KNOWLEDGE_SILO_MIN_SAMPLE_SIZE,
+	dominanceThreshold = KNOWLEDGE_SILO_DOMINANCE_THRESHOLD,
+} = {}) {
+	const sampleSize = names.length;
+	if (sampleSize < minSampleSize) {
+		return {
+			reason: "insufficient-sample",
+			dominantCount: 0,
+			dominantName: null,
+			dominanceRatio: 0,
+			sampleSize,
+			shouldWarn: false,
+		};
+	}
+	const counts = names.reduce((map, name) => {
+		map.set(name, (map.get(name) ?? 0) + 1);
+		return map;
+	}, new Map());
+	let dominantName = null;
+	let dominantCount = 0;
+	for (const [name, count] of counts.entries()) {
+		if (count > dominantCount) {
+			dominantName = name;
+			dominantCount = count;
+		}
+	}
+	const dominanceRatio = sampleSize === 0 ? 0 : dominantCount / sampleSize;
+	if (dominanceRatio < dominanceThreshold || dominantName == null) {
+		return {
+			reason: "balanced-ownership",
+			dominantCount,
+			dominantName,
+			dominanceRatio,
+			sampleSize,
+			shouldWarn: false,
+		};
+	}
+	return {
+		reason: "knowledge-silo",
+		dominantCount,
+		dominantName,
+		dominanceRatio,
+		sampleSize,
+		shouldWarn: true,
+	};
+}
+
+/**
+ * Builds a session-level warning key for the current silo result.
+ *
+ * @param {Object} options Warning metadata.
+ * @param {string} [options.href=""] Current page href.
+ * @param {string} [options.columnLabel=""] Matching ownership column label.
+ * @param {string|null} [options.dominantName=null] Dominant person name.
+ * @param {number} [options.dominantCount=0] Dominant record count.
+ * @param {number} [options.sampleSize=0] Sample size used by the heuristic.
+ * @return {string} Unique warning cache key.
+ */
+export function createKnowledgeSiloWarningKey({
+	href = "",
+	columnLabel = "",
+	dominantName = null,
+	dominantCount = 0,
+	sampleSize = 0,
+} = {}) {
+	return [
+		href,
+		columnLabel,
+		dominantName ?? "",
+		dominantCount,
+		sampleSize,
+	].join("|");
+}
+
+/**
+ * Resets the in-memory warning cache used for duplicate suppression.
+ *
+ * @return {void}
+ */
+export function resetKnowledgeSiloWarnings() {
+	WARNING_CACHE.clear();
+}
+
+/**
+ * Tracks a warning and returns whether it was already shown in this session.
+ *
+ * @param {string} warningKey Cache key representing a warning.
+ * @return {boolean} `true` when the warning was already shown.
+ */
+export function rememberKnowledgeSiloWarning(warningKey) {
+	if (WARNING_CACHE.has(warningKey)) {
+		return true;
+	}
+	WARNING_CACHE.add(warningKey);
+	return false;
+}
+
+/**
+ * Detects a likely knowledge silo from the currently visible setup table.
+ *
+ * @param {Object} [options={}] Detection options.
+ * @param {string} [options.href=globalThis.location?.href ?? ""] Current page href.
+ * @param {number} [options.minSampleSize=KNOWLEDGE_SILO_MIN_SAMPLE_SIZE] Minimum visible row count.
+ * @param {number} [options.dominanceThreshold=KNOWLEDGE_SILO_DOMINANCE_THRESHOLD] Dominance ratio threshold.
+ * @param {ParentNode} [options.root=document] Root node to inspect.
+ * @return {{
+ * 	columnIndex: number|null;
+ * 	columnLabel: string|null;
+ * 	dominantCount: number;
+ * 	dominantName: string|null;
+ * 	dominanceRatio: number;
+ * 	href: string;
+ * 	reason: string;
+ * 	sampleSize: number;
+ * 	shouldWarn: boolean;
+ * }} Structured detection result.
+ */
+export function detectKnowledgeSilo({
+	href = globalThis.location?.href ?? "",
+	minSampleSize = KNOWLEDGE_SILO_MIN_SAMPLE_SIZE,
+	dominanceThreshold = KNOWLEDGE_SILO_DOMINANCE_THRESHOLD,
+	root = document,
+} = {}) {
+	const tableMatch = findKnowledgeSiloTable(root);
+	if (tableMatch.table == null) {
+		return {
+			columnIndex: null,
+			columnLabel: null,
+			dominantCount: 0,
+			dominantName: null,
+			dominanceRatio: 0,
+			href,
+			reason: tableMatch.reason,
+			sampleSize: 0,
+			shouldWarn: false,
+		};
+	}
+	const names = extractKnowledgeSiloNames(
+		tableMatch.table,
+		tableMatch.columnIndex,
+	);
+	const analysis = analyzeKnowledgeSiloNames(names, {
+		minSampleSize,
+		dominanceThreshold,
+	});
+	const result = {
+		columnIndex: tableMatch.columnIndex,
+		columnLabel: tableMatch.columnLabel,
+		dominantCount: analysis.dominantCount,
+		dominantName: analysis.dominantName,
+		dominanceRatio: analysis.dominanceRatio,
+		href,
+		reason: analysis.reason,
+		sampleSize: analysis.sampleSize,
+		shouldWarn: analysis.shouldWarn,
+	};
+	if (!analysis.shouldWarn) {
+		return result;
+	}
+	const warningKey = createKnowledgeSiloWarningKey(result);
+	if (rememberKnowledgeSiloWarning(warningKey)) {
+		return {
+			...result,
+			reason: "duplicate-warning",
+			shouldWarn: false,
+		};
+	}
+	return result;
+}

--- a/src/settings/options.html
+++ b/src/settings/options.html
@@ -832,6 +832,26 @@
 							won’t appear in anonymous usage metrics.</span>
 					</help-aws>
 				</li>
+				<li>
+					<input
+						id="knowledge_silo_detection"
+						type="checkbox"
+					/>
+					<label for="knowledge_silo_detection">
+						<span data-i18n="opt_knowledge_silo_detection">
+							Warn when one person dominates the visible setup
+							records.
+						</span>
+					</label>
+					<help-aws>
+						<span
+							slot="text"
+							data-i18n="help_knowledge_silo_detection"
+						>Checks visible Setup list pages for Owner, Created By,
+							or Last Modified By columns and warns when one
+							person dominates the visible records.</span>
+					</help-aws>
+				</li>
 			</ul>
 			<hr>
 

--- a/src/settings/options.js
+++ b/src/settings/options.js
@@ -4,6 +4,7 @@ import {
 	GENERIC_PINNED_TAB_STYLE_KEY,
 	GENERIC_TAB_STYLE_KEY,
 	HIDDEN_CLASS,
+	KNOWLEDGE_SILO_DETECTION,
 	LINK_NEW_BROWSER,
 	NO_RELEASE_NOTES,
 	NO_UPDATE_NOTIFICATION,
@@ -149,6 +150,9 @@ const allCheckboxes = {
 	[NO_RELEASE_NOTES]: document.getElementById(NO_RELEASE_NOTES),
 	[NO_UPDATE_NOTIFICATION]: document.getElementById(NO_UPDATE_NOTIFICATION),
 	[PREVENT_ANALYTICS]: document.getElementById(PREVENT_ANALYTICS),
+	[KNOWLEDGE_SILO_DETECTION]: document.getElementById(
+		KNOWLEDGE_SILO_DETECTION,
+	),
 };
 
 const user_language_select = document.getElementById(USER_LANGUAGE);
@@ -916,6 +920,7 @@ function setCurrentChoice(setting) {
 		case NO_RELEASE_NOTES:
 		case NO_UPDATE_NOTIFICATION:
 		case PREVENT_ANALYTICS:
+		case KNOWLEDGE_SILO_DETECTION:
 			allCheckboxes[setting.id].checked = setting.enabled;
 			break;
 		case USER_LANGUAGE:

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -1,0 +1,377 @@
+import { assertEquals } from "@std/testing/asserts";
+import Window from "happydom";
+
+const OPTIONS_PATH = new URL("../src/settings/options.js", import.meta.url);
+const OPTIONS_HTML_PATH = new URL(
+	"../src/settings/options.html",
+	import.meta.url,
+);
+
+/**
+ * Replaces an import statement with blank lines so line numbers stay stable.
+ *
+ * @param {string} source Module source code.
+ * @param {string} fileName Import specifier to blank out.
+ * @return {string} Source with the import removed.
+ */
+function blankImport(source: string, fileName: string) {
+	const escapedFileName = fileName.replaceAll("/", "\\/");
+	return source
+		.replace(
+			new RegExp(
+				String.raw`import[\s\S]*?from\s*"${escapedFileName}";\n`,
+			),
+			(match) => "\n".repeat(match.split("\n").length - 1),
+		)
+		.replace(
+			new RegExp(String.raw`import\s*"${escapedFileName}";\n`),
+			(match) => "\n".repeat(match.split("\n").length - 1),
+		);
+}
+
+/**
+ * Encodes a signed integer using base64-VLQ for source-map generation.
+ *
+ * @param {number} value Integer to encode.
+ * @return {string} Encoded VLQ segment.
+ */
+function encodeVlqValue(value: number) {
+	const alphabet =
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+	let encoded = "";
+	let vlq = value < 0 ? ((-value) << 1) + 1 : value << 1;
+	do {
+		let digit = vlq & 31;
+		vlq >>>= 5;
+		if (vlq > 0) {
+			digit |= 32;
+		}
+		encoded += alphabet[digit];
+	} while (vlq > 0);
+	return encoded;
+}
+
+/**
+ * Builds a simple per-line inline source map back to the original options file.
+ *
+ * @param {Object} options Source-map options.
+ * @param {number[]} options.originalLines 1-based original line numbers per generated line.
+ * @param {string} options.sourceUrl Absolute source URL for the original module.
+ * @return {string} Base64-encoded JSON source-map payload.
+ */
+function buildInlineSourceMap({
+	originalLines,
+	sourceUrl,
+}: {
+	originalLines: number[];
+	sourceUrl: string;
+}) {
+	let previousOriginalLine = 0;
+	const mappings = originalLines.map((lineNumber) => {
+		if (lineNumber < 1) {
+			return "";
+		}
+		const segment = [
+			encodeVlqValue(0),
+			encodeVlqValue(0),
+			encodeVlqValue((lineNumber - 1) - previousOriginalLine),
+			encodeVlqValue(0),
+		].join("");
+		previousOriginalLine = lineNumber - 1;
+		return segment;
+	}).join(";");
+	return btoa(JSON.stringify({
+		version: 3,
+		file: OPTIONS_PATH.href,
+		sources: [sourceUrl],
+		names: [],
+		mappings,
+	}));
+}
+
+/**
+ * Loads the options module with injected test doubles.
+ *
+ * @param {Record<string, unknown>} deps Test doubles for module imports.
+ * @return {Promise<Record<string, unknown>>} Imported module namespace.
+ */
+async function loadOptionsModule(deps: Record<string, unknown>) {
+	let source = await Deno.readTextFile(OPTIONS_PATH);
+	for (
+		const fileName of [
+			"/constants.js",
+			"/functions.js",
+			"/translator.js",
+			"/components/theme-selector/theme-selector.js",
+		]
+	) {
+		source = blankImport(source, fileName);
+	}
+	const prelude = `
+const __deps = globalThis.__optionsTestDeps;
+const {
+	EXTENSION_NAME,
+	FOLLOW_SF_LANG,
+	GENERIC_PINNED_TAB_STYLE_KEY,
+	GENERIC_TAB_STYLE_KEY,
+	HIDDEN_CLASS,
+	KNOWLEDGE_SILO_DETECTION,
+	LINK_NEW_BROWSER,
+	NO_RELEASE_NOTES,
+	NO_UPDATE_NOTIFICATION,
+	ORG_PINNED_TAB_STYLE_KEY,
+	ORG_TAB_STYLE_KEY,
+	PERSIST_SORT,
+	POPUP_LOGIN_NEW_TAB,
+	POPUP_OPEN_LOGIN,
+	POPUP_OPEN_SETUP,
+	POPUP_SETUP_NEW_TAB,
+	PREVENT_ANALYTICS,
+	PREVENT_DEFAULT_OVERRIDE,
+	SETTINGS_KEY,
+	SKIP_LINK_DETECTION,
+	SLDS_ACTIVE,
+	TAB_ADD_FRONT,
+	TAB_AS_ORG,
+	TAB_GENERIC_STYLE,
+	TAB_ON_LEFT,
+	TAB_ORG_STYLE,
+	TAB_STYLE_BACKGROUND,
+	TAB_STYLE_BOLD,
+	TAB_STYLE_BORDER,
+	TAB_STYLE_COLOR,
+	TAB_STYLE_HOVER,
+	TAB_STYLE_ITALIC,
+	TAB_STYLE_SHADOW,
+	TAB_STYLE_TOP,
+	TAB_STYLE_UNDERLINE,
+	USE_LIGHTNING_NAVIGATION,
+	USER_LANGUAGE,
+	WHAT_SET,
+} = __deps.constants;
+const {
+	areFramePatternsAllowed,
+	getCssRule,
+	getCssSelector,
+	getPinnedSpecificKey,
+	getSettings,
+	getStyleSettings,
+	injectStyle,
+	isExportAllowed,
+	isGenericKey,
+	isPinnedKey,
+	isStyleKey,
+	requestCookiesPermission,
+	requestExportPermission,
+	requestFramePatternsPermission,
+	sendExtensionMessage,
+} = __deps.functions;
+const ensureTranslatorAvailability = __deps.ensureTranslatorAvailability;
+`;
+	const sourceLines = source.split("\n");
+	const preludeLines = prelude.split("\n");
+	const originalLines = [
+		...preludeLines.map(() => 0),
+		...sourceLines.map((_, index) => index + 1),
+	];
+	const inlineSourceMap = buildInlineSourceMap({
+		originalLines,
+		sourceUrl: OPTIONS_PATH.href,
+	});
+	const moduleUrl = URL.createObjectURL(
+		new Blob([`${preludeLines.join("\n")}\n${sourceLines.join("\n")}
+//# sourceMappingURL=data:application/json;base64,${inlineSourceMap}
+//# sourceURL=${OPTIONS_PATH.href}
+`], {
+			type: "text/javascript",
+		}),
+	);
+	try {
+		(globalThis as typeof globalThis & {
+			__optionsTestDeps?: Record<string, unknown>;
+		}).__optionsTestDeps = deps;
+		return await import(`${moduleUrl}#${crypto.randomUUID()}`);
+	} finally {
+		delete (globalThis as typeof globalThis & {
+			__optionsTestDeps?: Record<string, unknown>;
+		}).__optionsTestDeps;
+		URL.revokeObjectURL(moduleUrl);
+	}
+}
+
+/**
+ * Creates a realistic options page DOM and module dependency harness.
+ *
+ * @param {Array<Record<string, unknown>>} settings Settings returned by getSettings.
+ * @return {Promise<{
+ * 	cleanup: () => void;
+ * 	document: Document;
+ * 	records: { messages: Record<string, unknown>[] };
+ * }>} Harness state.
+ */
+async function createOptionsHarness(settings: Array<Record<string, unknown>>) {
+	const window = new Window({
+		url: "https://example.test/settings/options.html",
+	});
+	const html = await Deno.readTextFile(OPTIONS_HTML_PATH);
+	window.document.write(html);
+	const previousGlobals = new Map<string, unknown>();
+	for (
+		const [name, value] of Object.entries({
+			window,
+			document: window.document,
+			HTMLElement: window.HTMLElement,
+			CustomEvent: window.CustomEvent,
+			Event: window.Event,
+			Node: window.Node,
+			customElements: window.customElements,
+			navigator: window.navigator,
+			history: window.history,
+			location: window.location,
+		})
+	) {
+		previousGlobals.set(name, (globalThis as Record<string, unknown>)[name]);
+		Object.defineProperty(globalThis, name, {
+			value,
+			configurable: true,
+			writable: true,
+		});
+	}
+	const records = {
+		messages: [] as Record<string, unknown>[],
+	};
+	await loadOptionsModule({
+		constants: {
+			EXTENSION_NAME: "again-why-salesforce",
+			FOLLOW_SF_LANG: "follow-sf-lang",
+			GENERIC_PINNED_TAB_STYLE_KEY: "settings-tab_generic_style-pinned",
+			GENERIC_TAB_STYLE_KEY: "settings-tab_generic_style",
+			HIDDEN_CLASS: "hidden",
+			KNOWLEDGE_SILO_DETECTION: "knowledge_silo_detection",
+			LINK_NEW_BROWSER: "link_new_browser",
+			NO_RELEASE_NOTES: "no_release_notes",
+			NO_UPDATE_NOTIFICATION: "no_update_notification",
+			ORG_PINNED_TAB_STYLE_KEY: "settings-tab_org_style-pinned",
+			ORG_TAB_STYLE_KEY: "settings-tab_org_style",
+			PERSIST_SORT: "persist_sort",
+			POPUP_LOGIN_NEW_TAB: "popup_login_new_tab",
+			POPUP_OPEN_LOGIN: "popup_open_login",
+			POPUP_OPEN_SETUP: "popup_open_setup",
+			POPUP_SETUP_NEW_TAB: "popup_setup_new_tab",
+			PREVENT_ANALYTICS: "prevent_analytics",
+			PREVENT_DEFAULT_OVERRIDE: "user-set",
+			SETTINGS_KEY: "settings",
+			SKIP_LINK_DETECTION: "skip_link_detection",
+			SLDS_ACTIVE: "slds-is-active",
+			TAB_ADD_FRONT: "tab_add_front",
+			TAB_AS_ORG: "tab_as_org",
+			TAB_GENERIC_STYLE: "tab_generic_style",
+			TAB_ON_LEFT: "tab_position_left",
+			TAB_ORG_STYLE: "tab_org_style",
+			TAB_STYLE_BACKGROUND: "background",
+			TAB_STYLE_BOLD: "bold",
+			TAB_STYLE_BORDER: "border",
+			TAB_STYLE_COLOR: "color",
+			TAB_STYLE_HOVER: "hover",
+			TAB_STYLE_ITALIC: "italic",
+			TAB_STYLE_SHADOW: "shadow",
+			TAB_STYLE_TOP: "top",
+			TAB_STYLE_UNDERLINE: "underline",
+			USE_LIGHTNING_NAVIGATION: "use_lightning_navigation",
+			USER_LANGUAGE: "picked-language",
+			WHAT_SET: "set",
+		},
+		functions: {
+			areFramePatternsAllowed: () => Promise.resolve(false),
+			getCssRule: () => "",
+			getCssSelector: () => ".again-why-salesforce",
+			getPinnedSpecificKey: ({ isGeneric = true, isPinned = false } = {}) =>
+				isGeneric
+					? isPinned
+						? "settings-tab_generic_style-pinned"
+						: "settings-tab_generic_style"
+					: isPinned
+					? "settings-tab_org_style-pinned"
+					: "settings-tab_org_style",
+			getSettings: () => Promise.resolve(settings),
+			getStyleSettings: () => Promise.resolve(null),
+			injectStyle: () => {},
+			isExportAllowed: () => false,
+			isGenericKey: (key = "settings-tab_generic_style") =>
+				key.includes("tab_generic_style"),
+			isPinnedKey: (key = "settings-tab_generic_style") =>
+				key.includes("pinned"),
+			isStyleKey: (key = "") => key.startsWith("settings-tab_"),
+			requestCookiesPermission: () => Promise.resolve(true),
+			requestExportPermission: () => Promise.resolve(true),
+			requestFramePatternsPermission: () => Promise.resolve(true),
+			sendExtensionMessage: (message: Record<string, unknown>) => {
+				records.messages.push(message);
+				return Promise.resolve(true);
+			},
+		},
+		ensureTranslatorAvailability: () =>
+			Promise.resolve({
+				translate: (message: string | string[]) =>
+					Promise.resolve(
+						Array.isArray(message) ? message.join(" ") : message,
+					),
+			}),
+	});
+	return {
+		document: window.document,
+		records,
+		cleanup() {
+			window.close();
+			for (const [name, value] of previousGlobals.entries()) {
+				Object.defineProperty(globalThis, name, {
+					value,
+					configurable: true,
+					writable: true,
+				});
+			}
+		},
+	};
+}
+
+Deno.test("options restores the knowledge silo checkbox state", async () => {
+	const harness = await createOptionsHarness([{
+		id: "knowledge_silo_detection",
+		enabled: true,
+	}]);
+	try {
+		assertEquals(
+			(harness.document.getElementById(
+				"knowledge_silo_detection",
+			) as HTMLInputElement).checked,
+			true,
+		);
+		assertEquals(harness.records.messages.length, 0);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+Deno.test("options persists the knowledge silo checkbox through the shared settings flow", async () => {
+	const harness = await createOptionsHarness([{
+		id: "knowledge_silo_detection",
+		enabled: false,
+	}]);
+	try {
+		const checkbox = harness.document.getElementById(
+			"knowledge_silo_detection",
+		) as HTMLInputElement;
+		checkbox.checked = true;
+		checkbox.dispatchEvent(new Event("change", { bubbles: true }));
+		assertEquals(harness.records.messages, [{
+			what: "set",
+			key: "settings",
+			set: [{
+				id: "knowledge_silo_detection",
+				enabled: true,
+			}],
+		}]);
+	} finally {
+		harness.cleanup();
+	}
+});

--- a/tests/salesforce/content.test.ts
+++ b/tests/salesforce/content.test.ts
@@ -78,6 +78,12 @@ type ContentDeps = {
 	onceADay: {
 		executeOncePerDay: () => void;
 	};
+	knowledgeSilo: {
+		detectKnowledgeSilo: (options?: Record<string, unknown>) => Record<
+			string,
+			unknown
+		>;
+	};
 };
 
 /**
@@ -180,6 +186,7 @@ async function loadContentModule(deps: ContentDeps) {
 			"./manageTabs.js",
 			"./tutorial.js",
 			"./once-a-day.js",
+			"./knowledge-silo.js",
 		]
 	) {
 		source = blankImport(source, fileName);
@@ -216,6 +223,7 @@ const {
 	EXTENSION_NAME,
 	HAS_ORG_TAB,
 	HTTPS,
+	KNOWLEDGE_SILO_DETECTION,
 	LIGHTNING_FORCE_COM,
 	LINK_NEW_BROWSER,
 	SALESFORCE_URL_PATTERN,
@@ -270,6 +278,7 @@ const { createExportModal } = __deps.exportModule;
 const { createManageTabsModal } = __deps.manageTabs;
 const { checkTutorial, startTutorial } = __deps.tutorial;
 const { executeOncePerDay } = __deps.onceADay;
+const { detectKnowledgeSilo } = __deps.knowledgeSilo;
 `;
 	const sourceLines = source.split("\n");
 	const preludeLines = prelude.split("\n");
@@ -280,9 +289,11 @@ const { executeOncePerDay } = __deps.onceADay;
 		"\tcheckKeepTabsOnLeft,",
 		"\tdelayLoadSetupTabs,",
 		"\thideTabs,",
+		"\tisKnowledgeSiloDetectionEnabled,",
 		"\tinit,",
 		"\tlaunchDownload,",
 		"\tmain,",
+		"\tmaybeShowKnowledgeSiloWarning,",
 		"\tonHrefUpdate,",
 		"\tpromptUpdateExtension,",
 		"\treloadTabs,",
@@ -492,6 +503,7 @@ function createHarness(url = SETUP_URL) {
 		createImportModal: 0,
 		createExportModal: 0,
 		createManageTabsModal: 0,
+		knowledgeSiloCalls: [] as Array<Record<string, unknown>>,
 		rowTemplates: [] as Array<
 			{ row: Record<string, any>; conf: Record<string, any> }
 		>,
@@ -515,11 +527,26 @@ function createHarness(url = SETUP_URL) {
 	const state = {
 		settings: new Map<string, any>([
 			["tab_position_left", { id: "tab_position_left", enabled: false }],
+			["knowledge_silo_detection", {
+				id: "knowledge_silo_detection",
+				enabled: false,
+			}],
 			["skip_link_detection", {
 				id: "skip_link_detection",
 				enabled: false,
 			}],
 		]),
+		knowledgeSiloResult: {
+			columnIndex: 1,
+			columnLabel: "Owner",
+			dominantCount: 4,
+			dominantName: "Ada",
+			dominanceRatio: 0.8,
+			href: url,
+			reason: "knowledge-silo",
+			sampleSize: 5,
+			shouldWarn: true,
+		} as Record<string, unknown>,
 		innerFieldOverride: null as
 			| null
 			| ((options: {
@@ -930,6 +957,7 @@ function createHarness(url = SETUP_URL) {
 			EXTENSION_NAME: "again-why-salesforce",
 			HAS_ORG_TAB: ".has-org-tab",
 			HTTPS: "https://",
+			KNOWLEDGE_SILO_DETECTION: "knowledge_silo_detection",
 			LIGHTNING_FORCE_COM: ".lightning.force.com",
 			LINK_NEW_BROWSER: "link_new_browser",
 			SALESFORCE_URL_PATTERN: /^[a-z0-9-]+$/i,
@@ -1081,6 +1109,15 @@ function createHarness(url = SETUP_URL) {
 				records.executeOncePerDay++;
 			},
 		},
+		knowledgeSilo: {
+			detectKnowledgeSilo: (options = {}) => {
+				records.knowledgeSiloCalls.push(options);
+				return {
+					...state.knowledgeSiloResult,
+					href: options.href ?? state.knowledgeSiloResult.href,
+				};
+			},
+		},
 	};
 
 	return {
@@ -1148,6 +1185,7 @@ Deno.test("content.js bootstraps on setup pages and exposes current setup DOM", 
 		assertEquals(harness.records.executeOncePerDay, 1);
 		assertEquals(harness.records.styleCalls, 1);
 		assertEquals(harness.records.showFavouriteButton, 1);
+		assertEquals(harness.records.knowledgeSiloCalls.length, 0);
 		assertEquals(harness.allTabs.length, 2);
 		assertEquals(setupTabUl.childElementCount, 2);
 		assertEquals(harness.records.rowTemplates[1].conf.hide, true);
@@ -1155,6 +1193,74 @@ Deno.test("content.js bootstraps on setup pages and exposes current setup DOM", 
 		assertEquals(harness.browser.runtime._listeners.length, 1);
 		assertEquals(globalThis.hasLoadedagainwhysalesforce, undefined);
 		assertEquals(globalThis["hasLoadedagain-why-salesforce"], true);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+Deno.test("content.js runs the knowledge silo detector on setup load when enabled", async () => {
+	const harness = createHarness();
+	try {
+		harness.state.settings.set("knowledge_silo_detection", {
+			id: "knowledge_silo_detection",
+			enabled: true,
+		});
+		const content = await harness.load();
+		await harness.flush();
+		assertEquals(harness.records.knowledgeSiloCalls.length, 1);
+		assertEquals(harness.records.knowledgeSiloCalls[0].href, SETUP_URL);
+		assertEquals(harness.records.toasts.at(-1), {
+			message: [
+				"knowledge_silo_warning",
+				"Ada",
+				"knowledge_silo_dominates",
+				"4/5",
+				"knowledge_silo_visible_rows_in",
+				"Owner",
+			],
+			status: "warning",
+		});
+		assertExists(content.getSetupTabUl());
+	} finally {
+		harness.cleanup();
+	}
+});
+
+Deno.test("content.js reruns the knowledge silo detector on setup route changes", async () => {
+	const harness = createHarness();
+	try {
+		harness.state.settings.set("knowledge_silo_detection", {
+			id: "knowledge_silo_detection",
+			enabled: true,
+		});
+		const content = await harness.load();
+		await harness.flush();
+		harness.state.knowledgeSiloResult = {
+			...harness.state.knowledgeSiloResult,
+			columnLabel: "Created By",
+			dominantCount: 5,
+			dominantName: "Grace",
+			href: USERS_URL,
+			sampleSize: 6,
+		};
+		harness.setUrl(USERS_URL);
+		harness.triggerMutation();
+		harness.flushTimers();
+		await harness.flush();
+		assertEquals(harness.records.knowledgeSiloCalls.length, 2);
+		assertEquals(harness.records.knowledgeSiloCalls.at(-1)?.href, USERS_URL);
+		assertEquals(harness.records.toasts.at(-1), {
+			message: [
+				"knowledge_silo_warning",
+				"Grace",
+				"knowledge_silo_dominates",
+				"5/6",
+				"knowledge_silo_visible_rows_in",
+				"Created By",
+			],
+			status: "warning",
+		});
+		assertExists(content.getSetupTabUl());
 	} finally {
 		harness.cleanup();
 	}

--- a/tests/salesforce/knowledge-silo.test.ts
+++ b/tests/salesforce/knowledge-silo.test.ts
@@ -1,0 +1,246 @@
+import { assertEquals } from "@std/testing/asserts";
+import { installMockDom } from "../happydom.ts";
+import {
+	analyzeKnowledgeSiloNames,
+	createKnowledgeSiloWarningKey,
+	detectKnowledgeSilo,
+	resetKnowledgeSiloWarnings,
+} from "/salesforce/knowledge-silo.js";
+
+/**
+ * Appends a simple table to the current document body.
+ *
+ * @param {string[]} headers Header labels.
+ * @param {Array<Array<string | { text: string; hidden?: boolean }>>} rows Row cell values.
+ * @return {HTMLTableElement} Rendered table element.
+ */
+function appendKnowledgeSiloTable(headers, rows) {
+	const table = document.createElement("table");
+	const thead = document.createElement("thead");
+	const headerRow = document.createElement("tr");
+	for (const header of headers) {
+		const cell = document.createElement("th");
+		cell.textContent = header;
+		headerRow.appendChild(cell);
+	}
+	thead.appendChild(headerRow);
+	const tbody = document.createElement("tbody");
+	for (const rowData of rows) {
+		const row = document.createElement("tr");
+		for (const cellData of rowData) {
+			const cell = document.createElement("td");
+			if (typeof cellData === "string") {
+				cell.textContent = cellData;
+			} else {
+				cell.textContent = cellData.text;
+				if (cellData.hidden) {
+					cell.style.display = "none";
+					row.style.display = "none";
+				}
+			}
+			row.appendChild(cell);
+		}
+		tbody.appendChild(row);
+	}
+	table.append(thead, tbody);
+	document.body.appendChild(table);
+	return table;
+}
+
+Deno.test("detectKnowledgeSilo reports unsupported pages when no tables are visible", () => {
+	const dom = installMockDom("https://acme.lightning.force.com/lightning/setup/Users/home");
+	try {
+		resetKnowledgeSiloWarnings();
+		assertEquals(
+			detectKnowledgeSilo(),
+			{
+				columnIndex: null,
+				columnLabel: null,
+				dominantCount: 0,
+				dominantName: null,
+				dominanceRatio: 0,
+				href:
+					"https://acme.lightning.force.com/lightning/setup/Users/home",
+				reason: "unsupported-page",
+				sampleSize: 0,
+				shouldWarn: false,
+			},
+		);
+	} finally {
+		dom.cleanup();
+		resetKnowledgeSiloWarnings();
+	}
+});
+
+Deno.test("detectKnowledgeSilo ignores tables without ownership columns", () => {
+	const dom = installMockDom("https://acme.lightning.force.com/lightning/setup/Users/home");
+	try {
+		appendKnowledgeSiloTable(
+			["Label", "Type"],
+			[
+				["A", "Flow"],
+				["B", "Profile"],
+			],
+		);
+		resetKnowledgeSiloWarnings();
+		assertEquals(detectKnowledgeSilo().reason, "missing-column");
+	} finally {
+		dom.cleanup();
+		resetKnowledgeSiloWarnings();
+	}
+});
+
+Deno.test("detectKnowledgeSilo requires a minimum visible sample size", () => {
+	const dom = installMockDom("https://acme.lightning.force.com/lightning/setup/Users/home");
+	try {
+		appendKnowledgeSiloTable(
+			["Name", "Owner"],
+			[
+				["Alpha", "Ada"],
+				["Beta", "Ada"],
+				["Gamma", "Ada"],
+				["Delta", "Ada"],
+			],
+		);
+		resetKnowledgeSiloWarnings();
+		assertEquals(
+			detectKnowledgeSilo(),
+			{
+				columnIndex: 1,
+				columnLabel: "Owner",
+				dominantCount: 0,
+				dominantName: null,
+				dominanceRatio: 0,
+				href:
+					"https://acme.lightning.force.com/lightning/setup/Users/home",
+				reason: "insufficient-sample",
+				sampleSize: 4,
+				shouldWarn: false,
+			},
+		);
+	} finally {
+		dom.cleanup();
+		resetKnowledgeSiloWarnings();
+	}
+});
+
+Deno.test("detectKnowledgeSilo ignores balanced ownership", () => {
+	const dom = installMockDom("https://acme.lightning.force.com/lightning/setup/Users/home");
+	try {
+		appendKnowledgeSiloTable(
+			["Name", "Last Modified By"],
+			[
+				["Alpha", "Ada"],
+				["Beta", "Grace"],
+				["Gamma", "Ada"],
+				["Delta", "Grace"],
+				["Epsilon", "Ada"],
+				["Zeta", "Grace"],
+			],
+		);
+		resetKnowledgeSiloWarnings();
+		assertEquals(detectKnowledgeSilo().reason, "balanced-ownership");
+	} finally {
+		dom.cleanup();
+		resetKnowledgeSiloWarnings();
+	}
+});
+
+Deno.test("detectKnowledgeSilo warns when one visible owner dominates", () => {
+	const dom = installMockDom("https://acme.lightning.force.com/lightning/setup/Users/home");
+	try {
+		appendKnowledgeSiloTable(
+			["Name", "Created By"],
+			[
+				["Alpha", "Ada"],
+				["Beta", "Ada"],
+				["Gamma", "Ada"],
+				["Delta", "Grace"],
+				["Epsilon", "Ada"],
+				["Hidden", { text: "Grace", hidden: true }],
+			],
+		);
+		resetKnowledgeSiloWarnings();
+		assertEquals(
+			detectKnowledgeSilo(),
+			{
+				columnIndex: 1,
+				columnLabel: "Created By",
+				dominantCount: 4,
+				dominantName: "Ada",
+				dominanceRatio: 0.8,
+				href:
+					"https://acme.lightning.force.com/lightning/setup/Users/home",
+				reason: "knowledge-silo",
+				sampleSize: 5,
+				shouldWarn: true,
+			},
+		);
+	} finally {
+		dom.cleanup();
+		resetKnowledgeSiloWarnings();
+	}
+});
+
+Deno.test("detectKnowledgeSilo suppresses duplicate warnings in the same session", () => {
+	const dom = installMockDom("https://acme.lightning.force.com/lightning/setup/Users/home");
+	try {
+		appendKnowledgeSiloTable(
+			["Name", "Owner"],
+			[
+				["Alpha", "Ada"],
+				["Beta", "Ada"],
+				["Gamma", "Ada"],
+				["Delta", "Grace"],
+				["Epsilon", "Ada"],
+			],
+		);
+		resetKnowledgeSiloWarnings();
+		assertEquals(detectKnowledgeSilo().reason, "knowledge-silo");
+		assertEquals(detectKnowledgeSilo().reason, "duplicate-warning");
+	} finally {
+		dom.cleanup();
+		resetKnowledgeSiloWarnings();
+	}
+});
+
+Deno.test("knowledge silo helpers cover empty samples and default fallbacks", () => {
+	const originalLocation = globalThis.location;
+	try {
+		assertEquals(
+			analyzeKnowledgeSiloNames([], { minSampleSize: 0 }),
+			{
+				reason: "balanced-ownership",
+				dominantCount: 0,
+				dominantName: null,
+				dominanceRatio: 0,
+				sampleSize: 0,
+				shouldWarn: false,
+			},
+		);
+		assertEquals(
+			createKnowledgeSiloWarningKey({
+				columnLabel: "Owner",
+				dominantCount: 4,
+				sampleSize: 5,
+			}),
+			"|Owner||4|5",
+		);
+		delete (globalThis as Record<string, unknown>).location;
+		assertEquals(
+			detectKnowledgeSilo({
+				root: {
+					querySelectorAll: () => [],
+				} as ParentNode,
+			}).href,
+			"",
+		);
+	} finally {
+		Object.defineProperty(globalThis, "location", {
+			value: originalLocation,
+			configurable: true,
+			writable: true,
+		});
+		resetKnowledgeSiloWarnings();
+	}
+});


### PR DESCRIPTION
## Summary
- add an opt-in Salesforce Setup knowledge silo detector based on visible Owner, Created By, and Last Modified By columns
- warn through the existing toast UI when at least 5 visible rows are present and one person owns at least 60% of the visible records
- cover the detector heuristics, content-script lifecycle wiring, and settings restore/persist flow with Deno tests

## Assumptions
- this extension has no backend team model, so the detector only analyzes data visible on the current Setup list page
- the heuristic is intentionally conservative and only inspects visible rows on eligible Setup list pages
- duplicate warnings are suppressed for the same page/result within the current session