### PR TITLE
Add static metrics coverage analyzer

### DIFF
--- a/bin/metrics-coverage.ts
+++ b/bin/metrics-coverage.ts
@@ -1,0 +1,564 @@
+#!/usr/bin/env -S deno run --allow-read
+
+const COVERED = "covered";
+const PARTIAL = "partial";
+const UNCOVERED = "uncovered";
+
+type CoverageStatus = "covered" | "partial" | "uncovered";
+
+type SourceMatcher = {
+	id: string;
+	description: string;
+	pattern: RegExp;
+};
+
+type SourceRule = {
+	path: string;
+	matchers: SourceMatcher[];
+};
+
+type TestRule = {
+	path: string;
+	requiredTitles: string[];
+};
+
+type InstrumentationTargetRule = {
+	id: string;
+	title: string;
+	description: string;
+	source: SourceRule;
+	tests: TestRule;
+};
+
+type SourceLocation = {
+	matcherId: string;
+	description: string;
+	path: string;
+	line: number;
+};
+
+type TestLocation = {
+	path: string;
+	line: number;
+	title: string;
+};
+
+type CoverageTargetResult = {
+	id: string;
+	title: string;
+	description: string;
+	status: CoverageStatus;
+	sourceLocations: SourceLocation[];
+	validatingTests: TestLocation[];
+	missingSourceMatchers: string[];
+	missingTestTitles: string[];
+};
+
+type MetricsCoverageReport = {
+	totals: {
+		targets: number;
+		covered: number;
+		partial: number;
+		uncovered: number;
+	};
+	scope: {
+		assumptions: string[];
+		sourceFiles: string[];
+		testFiles: string[];
+	};
+	matrix: CoverageTargetResult[];
+};
+
+const SCOPE_ASSUMPTIONS = [
+	"Metrics instrumentation scope is limited to analytics beacon and usage-day tracking flows.",
+	"Analyzer is static and pattern-based; runtime behavior is not executed.",
+	"Coverage is inferred from named Deno.test cases mapped to explicit instrumentation rules.",
+];
+
+/**
+ * Returns explicit instrumentation target rules for static analysis.
+ *
+ * @return {InstrumentationTargetRule[]} Rule definitions in deterministic order.
+ */
+export function getInstrumentationRules(): InstrumentationTargetRule[] {
+	return [
+		{
+			id: "analytics-beacon-insertion",
+			title: "Analytics beacon insertion",
+			description:
+				"Simple Analytics beacon and CSP insertion in analytics telemetry flow.",
+			source: {
+				path: "src/salesforce/analytics.js",
+				matchers: [
+					{
+						id: "send-ping-function",
+						description: "sendPingToAnalytics function exists",
+						pattern: /sendPingToAnalytics\s*\(/,
+					},
+					{
+						id: "beacon-url",
+						description: "noscript beacon URL is assembled",
+						pattern: /noscript\.gif/,
+					},
+					{
+						id: "persist-ping-date",
+						description: "analytics ping date is persisted",
+						pattern: /setDateForPingToday\s*\(\)/,
+					},
+				],
+			},
+			tests: {
+				path: "tests/salesforce/analytics.test.ts",
+				requiredTitles: [
+					"inserts beacon for a new Firefox user with consent",
+					"skips a second beacon on the same day",
+					"appends analytics domains to an existing CSP",
+				],
+			},
+		},
+		{
+			id: "analytics-consent-opt-out",
+			title: "Analytics consent and opt-out",
+			description:
+				"Firefox consent evaluation and PREVENT_ANALYTICS synchronization logic.",
+			source: {
+				path: "src/salesforce/analytics.js",
+				matchers: [
+					{
+						id: "consent-check",
+						description: "technical and interaction consent is read",
+						pattern: /getTechnicalAndInteractionConsent\s*\(\)/,
+					},
+					{
+						id: "opt-out-fallback",
+						description: "local opt-out fallback branch exists",
+						pattern: /consentGranted\s*==\s*null/,
+					},
+					{
+						id: "opt-out-sync",
+						description: "PREVENT_ANALYTICS enabled flag is synchronized",
+						pattern: /id:\s*PREVENT_ANALYTICS[\s\S]*enabled:\s*shouldPreventAnalytics/,
+					},
+				],
+			},
+			tests: {
+				path: "tests/salesforce/analytics.test.ts",
+				requiredTitles: [
+					"syncs opt-out on Firefox consent denial",
+					"falls back to the local opt-out if Firefox consent check fails",
+					"on Chrome skips Firefox consent checks",
+				],
+			},
+		},
+		{
+			id: "usage-days-update-persistence",
+			title: "Usage-days persistence",
+			description:
+				"Persisted usage-days telemetry update path through settings messaging.",
+			source: {
+				path: "src/salesforce/update-settings.js",
+				matchers: [
+					{
+						id: "update-function",
+						description: "updateExtensionUsageDays entrypoint exists",
+						pattern: /export\s+async\s+function\s+updateExtensionUsageDays/,
+					},
+					{
+						id: "usage-calculation-call",
+						description: "getUsageDaysUpdate is called from updater",
+						pattern: /getUsageDaysUpdate\s*\(\s*usageSettings\s*\)/,
+					},
+					{
+						id: "settings-write",
+						description: "updated usage telemetry is persisted",
+						pattern: /sendExtensionMessage\s*\([\s\S]*what:\s*"set"/,
+					},
+				],
+			},
+			tests: {
+				path: "tests/salesforce/update-settings.test.ts",
+				requiredTitles: [
+					"initializes missing usage tracking at zero",
+					"increments usage days on a new day",
+					"persists the usage settings",
+				],
+			},
+		},
+		{
+			id: "usage-days-daily-calculation",
+			title: "Usage-days daily calculation",
+			description:
+				"Daily distinct-use-day calculation and non-increment branch behavior.",
+			source: {
+				path: "src/salesforce/update-settings.js",
+				matchers: [
+					{
+						id: "calculation-function",
+						description: "getUsageDaysUpdate function exists",
+						pattern: /export\s+function\s+getUsageDaysUpdate/,
+					},
+					{
+						id: "new-day-branch",
+						description: "new day branch increments usage",
+						pattern: /lastActiveDay\s*!==\s*today/,
+					},
+				],
+			},
+			tests: {
+				path: "tests/salesforce/update-settings.test.ts",
+				requiredTitles: [
+					"does not increment twice on the same day",
+					"handles null settings input",
+				],
+			},
+		},
+		{
+			id: "once-a-day-telemetry-trigger",
+			title: "Once-a-day telemetry trigger",
+			description:
+				"Daily gating that triggers analytics check and usage-days update once per day.",
+			source: {
+				path: "src/salesforce/once-a-day.js",
+				matchers: [
+					{
+						id: "execute-function",
+						description: "executeOncePerDay entrypoint exists",
+						pattern: /export\s+function\s+executeOncePerDay/,
+					},
+					{
+						id: "daily-guard",
+						description: "same-day guard branch exists",
+						pattern: /wasCalledToday\s*\(\s*today\s*\)/,
+					},
+					{
+						id: "analytics-trigger",
+						description: "analytics trigger is called",
+						pattern: /checkInsertAnalytics\s*\(\s*\)/,
+					},
+					{
+						id: "usage-days-trigger",
+						description: "usage-days trigger is called",
+						pattern: /updateExtensionUsageDays\s*\(\s*\)/,
+					},
+				],
+			},
+			tests: {
+				path: "tests/salesforce/once-a-day.test.ts",
+				requiredTitles: [
+					"formats the local calendar day",
+					"runs the first time but not the second",
+				],
+			},
+		},
+	];
+}
+
+/**
+ * Reads a file as UTF-8 text if it exists.
+ *
+ * @param {string} rootDir - Root directory for relative file resolution.
+ * @param {string} relativePath - Path to read relative to rootDir.
+ * @return {Promise<string|null>} File content when found, otherwise null.
+ */
+async function readTextIfExists(
+	rootDir: string,
+	relativePath: string,
+): Promise<string | null> {
+	const absolutePath = `${rootDir}/${relativePath}`;
+	try {
+		return await Deno.readTextFile(absolutePath);
+	} catch (error) {
+		if (error instanceof Deno.errors.NotFound) {
+			return null;
+		}
+		throw error;
+	}
+}
+
+/**
+ * Converts a character index into a 1-based line number.
+ *
+ * @param {string} content - File text content.
+ * @param {number} index - Character index of a match.
+ * @return {number} 1-based line number.
+ */
+function toLineNumber(content: string, index: number): number {
+	return content.slice(0, index).split("\n").length;
+}
+
+/**
+ * Extracts named Deno.test declarations from a test file.
+ *
+ * @param {string} filePath - Relative file path for metadata.
+ * @param {string} content - Raw test file content.
+ * @return {TestLocation[]} Parsed test definitions.
+ */
+function extractTestLocations(filePath: string, content: string): TestLocation[] {
+	const results: TestLocation[] = [];
+	const pattern = /Deno\.test\(\s*["'`]([^"'`]+)["'`]/g;
+	let match = pattern.exec(content);
+	while (match != null) {
+		results.push({
+			path: filePath,
+			line: toLineNumber(content, match.index),
+			title: match[1],
+		});
+		match = pattern.exec(content);
+	}
+	return results;
+}
+
+/**
+ * Finds source matcher hits and missing matcher ids for one rule.
+ *
+ * @param {SourceRule} sourceRule - Source matching rule.
+ * @param {string|null} content - Source file content, if readable.
+ * @return {{ locations: SourceLocation[]; missingMatcherIds: string[] }} Match result payload.
+ */
+function evaluateSourceRule(
+	sourceRule: SourceRule,
+	content: string | null,
+): { locations: SourceLocation[]; missingMatcherIds: string[] } {
+	if (content == null) {
+		return {
+			locations: [],
+			missingMatcherIds: sourceRule.matchers.map((matcher) => matcher.id),
+		};
+	}
+
+	const locations: SourceLocation[] = [];
+	const missingMatcherIds: string[] = [];
+	for (const matcher of sourceRule.matchers) {
+		const hit = matcher.pattern.exec(content);
+		if (hit == null || hit.index == null) {
+			missingMatcherIds.push(matcher.id);
+			continue;
+		}
+		locations.push({
+			matcherId: matcher.id,
+			description: matcher.description,
+			path: sourceRule.path,
+			line: toLineNumber(content, hit.index),
+		});
+	}
+
+	locations.sort((a, b) => a.line - b.line || a.matcherId.localeCompare(b.matcherId));
+	return { locations, missingMatcherIds };
+}
+
+/**
+ * Finds test cases that validate one instrumentation target.
+ *
+ * @param {TestRule} testRule - Test matching rule.
+ * @param {TestLocation[]} tests - Parsed tests from the designated file.
+ * @return {{ validatingTests: TestLocation[]; missingTitles: string[] }} Matching test payload.
+ */
+function evaluateTestRule(
+	testRule: TestRule,
+	tests: TestLocation[],
+): { validatingTests: TestLocation[]; missingTitles: string[] } {
+	const validatingTests: TestLocation[] = [];
+	const missingTitles: string[] = [];
+	for (const expectedTitle of testRule.requiredTitles) {
+		const matching = tests.filter((testCase) =>
+			testCase.title.includes(expectedTitle)
+		);
+		if (matching.length === 0) {
+			missingTitles.push(expectedTitle);
+			continue;
+		}
+		for (const testCase of matching) {
+			validatingTests.push(testCase);
+		}
+	}
+
+	const unique = new Map<string, TestLocation>();
+	for (const testCase of validatingTests) {
+		unique.set(`${testCase.path}:${testCase.line}:${testCase.title}`, testCase);
+	}
+	const uniqueTests = [...unique.values()];
+	uniqueTests.sort((a, b) => a.line - b.line);
+
+	return {
+		validatingTests: uniqueTests,
+		missingTitles,
+	};
+}
+
+/**
+ * Converts source and test match completeness into a coverage status label.
+ *
+ * @param {boolean} hasSourceMatches - Whether at least one source matcher was found.
+ * @param {number} missingSourceCount - Missing source matcher count.
+ * @param {number} missingTestCount - Missing test title count.
+ * @param {number} validatingTestCount - Matched validating test count.
+ * @return {CoverageStatus} Status classification.
+ */
+function resolveStatus(
+	hasSourceMatches: boolean,
+	missingSourceCount: number,
+	missingTestCount: number,
+	validatingTestCount: number,
+): CoverageStatus {
+	if (!hasSourceMatches || validatingTestCount === 0) {
+		return UNCOVERED;
+	}
+	if (missingSourceCount === 0 && missingTestCount === 0) {
+		return COVERED;
+	}
+	return PARTIAL;
+}
+
+/**
+ * Builds a static metrics coverage report from explicit instrumentation rules.
+ *
+ * @param {string} [rootDir=Deno.cwd()] - Root directory to analyze.
+ * @return {Promise<MetricsCoverageReport>} Coverage matrix report.
+ */
+export async function analyzeMetricsCoverage(
+	rootDir = Deno.cwd(),
+): Promise<MetricsCoverageReport> {
+	const rules = getInstrumentationRules();
+	const sourcePaths = [...new Set(rules.map((rule) => rule.source.path))];
+	const testPaths = [...new Set(rules.map((rule) => rule.tests.path))];
+
+	const sourceContentByPath = new Map<string, string | null>();
+	for (const sourcePath of sourcePaths) {
+		sourceContentByPath.set(sourcePath, await readTextIfExists(rootDir, sourcePath));
+	}
+
+	const testCasesByPath = new Map<string, TestLocation[]>();
+	for (const testPath of testPaths) {
+		const testContent = await readTextIfExists(rootDir, testPath);
+		const testCases = testContent == null ? [] : extractTestLocations(testPath, testContent);
+		testCasesByPath.set(testPath, testCases);
+	}
+
+	const matrix: CoverageTargetResult[] = [];
+	for (const rule of rules) {
+		const sourceContent = sourceContentByPath.get(rule.source.path) ?? null;
+		const sourceEvaluation = evaluateSourceRule(rule.source, sourceContent);
+		const tests = testCasesByPath.get(rule.tests.path) as TestLocation[];
+		const testEvaluation = evaluateTestRule(rule.tests, tests);
+
+		const status = resolveStatus(
+			sourceEvaluation.locations.length > 0,
+			sourceEvaluation.missingMatcherIds.length,
+			testEvaluation.missingTitles.length,
+			testEvaluation.validatingTests.length,
+		);
+
+		matrix.push({
+			id: rule.id,
+			title: rule.title,
+			description: rule.description,
+			status,
+			sourceLocations: sourceEvaluation.locations,
+			validatingTests: testEvaluation.validatingTests,
+			missingSourceMatchers: sourceEvaluation.missingMatcherIds,
+			missingTestTitles: testEvaluation.missingTitles,
+		});
+	}
+
+	const totals = {
+		targets: matrix.length,
+		covered: matrix.filter((entry) => entry.status === COVERED).length,
+		partial: matrix.filter((entry) => entry.status === PARTIAL).length,
+		uncovered: matrix.filter((entry) => entry.status === UNCOVERED).length,
+	};
+
+	return {
+		totals,
+		scope: {
+			assumptions: SCOPE_ASSUMPTIONS,
+			sourceFiles: sourcePaths,
+			testFiles: testPaths,
+		},
+		matrix,
+	};
+}
+
+/**
+ * Serializes the report to deterministic JSON for CI/PR consumption.
+ *
+ * @param {MetricsCoverageReport} report - Coverage report to serialize.
+ * @param {boolean} [pretty=true] - Whether to pretty-print JSON.
+ * @return {string} Serialized JSON payload.
+ */
+export function serializeMetricsCoverageReport(
+	report: MetricsCoverageReport,
+	pretty = true,
+): string {
+	return JSON.stringify(report, null, pretty ? "\t" : undefined);
+}
+
+/**
+ * Parses known CLI flags.
+ *
+ * @param {string[]} args - Command-line arguments.
+ * @return {{ rootDir: string; pretty: boolean; help: boolean }} Parsed options.
+ */
+function parseArgs(
+	args: string[],
+): { rootDir: string; pretty: boolean; help: boolean } {
+	const options = {
+		rootDir: Deno.cwd(),
+		pretty: true,
+		help: false,
+	};
+	for (let index = 0; index < args.length; index += 1) {
+		const arg = args[index];
+		if (arg === "--help" || arg === "-h") {
+			options.help = true;
+			continue;
+		}
+		if (arg === "--compact") {
+			options.pretty = false;
+			continue;
+		}
+		if (arg === "--root") {
+			options.rootDir = args[index + 1] ?? options.rootDir;
+			index += 1;
+			continue;
+		}
+	}
+	return options;
+}
+
+/**
+ * Builds the CLI usage output.
+ *
+ * @return {string} Human-readable usage text.
+ */
+function getUsage() {
+	return [
+		"Usage: deno run --allow-read bin/metrics-coverage.ts [--root <path>] [--compact]",
+		"",
+		"Options:",
+		"  --root <path>  Analyze a specific repository root (default: current directory).",
+		"  --compact      Emit minified JSON instead of pretty JSON.",
+		"  -h, --help     Show this help text.",
+	].join("\n");
+}
+
+/**
+ * Executes the CLI entrypoint.
+ *
+ * @param {string[]} [args=Deno.args] - Command-line arguments.
+ * @return {Promise<number>} Process exit code.
+ */
+export async function runCli(args: string[] = Deno.args): Promise<number> {
+	const options = parseArgs(args);
+	if (options.help) {
+		console.log(getUsage());
+		return 0;
+	}
+	const report = await analyzeMetricsCoverage(options.rootDir);
+	console.log(serializeMetricsCoverageReport(report, options.pretty));
+	return 0;
+}
+
+if (import.meta.main) {
+	const code = await runCli(Deno.args);
+	Deno.exit(code);
+}

--- a/deno.json
+++ b/deno.json
@@ -25,6 +25,7 @@
 
 		"fmt": "deno fmt",
 		"lint": "deno lint",
+		"metrics-coverage": "deno run --allow-read bin/metrics-coverage.ts",
 		"sort": "deno --allow-read --allow-write bin/sort-locales.ts && git add src/_locales/*/messages.json",
 		"locale-check": "deno --allow-read --allow-write bin/find-invalid-variables.ts && deno --allow-read --allow-write bin/missing-locales.ts",
 		"locales": "deno task locale-check && deno task sort",

--- a/docs/METRICS_COVERAGE_ANALYZER.md
+++ b/docs/METRICS_COVERAGE_ANALYZER.md
@@ -1,0 +1,47 @@
+# Metrics Coverage Analyzer
+
+## Scope Assumptions
+
+This analyzer intentionally uses a minimal static scope:
+
+- Metrics instrumentation means telemetry paths in:
+  - `src/salesforce/analytics.js` (Simple Analytics beacon and opt-out/consent handling)
+  - `src/salesforce/update-settings.js` (usage-days tracking)
+  - `src/salesforce/once-a-day.js` (daily trigger for telemetry paths)
+- The analyzer does not execute extension code and does not validate runtime behavior.
+- Coverage is inferred by mapping explicit source patterns to explicit `Deno.test(...)` names.
+
+## Command Usage
+
+Run from repository root:
+
+```bash
+deno task metrics-coverage
+```
+
+Alternative CLI options:
+
+```bash
+deno run --allow-read bin/metrics-coverage.ts --root .
+deno run --allow-read bin/metrics-coverage.ts --compact
+```
+
+## Output Schema
+
+The command emits JSON with this top-level structure:
+
+- `totals`: aggregate counts by coverage status (`covered`, `partial`, `uncovered`)
+- `scope`: static assumptions and file set used by the analyzer
+- `matrix`: one entry per instrumentation target with:
+  - `id`, `title`, `description`
+  - `status`
+  - `sourceLocations`: matched source pattern locations (`path`, `line`, matcher metadata)
+  - `validatingTests`: mapped test cases (`path`, `line`, `title`)
+  - `missingSourceMatchers`: expected source matchers not found
+  - `missingTestTitles`: expected validating test titles not found
+
+## Known Limitations
+
+- Static matching can miss valid coverage when source/test patterns are renamed or refactored.
+- Test-title matching is substring-based and cannot guarantee assertion quality.
+- The analyzer only includes the explicit rule set in `bin/metrics-coverage.ts`; it is not generic telemetry discovery.

--- a/tests/bin/metrics-coverage.test.ts
+++ b/tests/bin/metrics-coverage.test.ts
@@ -1,0 +1,312 @@
+import {
+	assertEquals,
+	assertGreater,
+	assertStringIncludes,
+} from "@std/testing/asserts";
+import {
+	analyzeMetricsCoverage,
+	getInstrumentationRules,
+	runCli,
+	serializeMetricsCoverageReport,
+} from "../../bin/metrics-coverage.ts";
+
+/**
+ * Writes a fixture tree into a temporary directory.
+ *
+ * @param {Record<string, string>} files - Relative fixture paths and file contents.
+ * @return {Promise<string>} Temporary root directory path.
+ */
+async function writeFixtureTree(files: Record<string, string>) {
+	const rootDir = await Deno.makeTempDir();
+	for (const [relativePath, content] of Object.entries(files)) {
+		const absolutePath = `${rootDir}/${relativePath}`;
+		const parentPath = absolutePath.split("/").slice(0, -1).join("/");
+		await Deno.mkdir(parentPath, { recursive: true });
+		await Deno.writeTextFile(absolutePath, content);
+	}
+	return rootDir;
+}
+
+/**
+ * Builds minimal source fixtures that satisfy all analyzer source rules.
+ *
+ * @return {Record<string, string>} Fixture source files keyed by relative path.
+ */
+function buildCoveredSourceFixtures() {
+	return {
+		"src/salesforce/analytics.js": [
+			"function getTechnicalAndInteractionConsent() {}",
+			"function setDateForPingToday() {}",
+			"function sendPingToAnalytics() {",
+			"\tconst apiUrl = new URL(\"noscript.gif\", \"https://queue.simpleanalyticscdn.com\");",
+			"\tsetDateForPingToday();",
+			"}",
+			"async function checkInsertAnalytics() {",
+			"\tconst consentGranted = true;",
+			"\tconst shouldPreventAnalytics = consentGranted == null ? true : false;",
+			"\tawait syncAnalyticsSetting({ id: PREVENT_ANALYTICS, enabled: shouldPreventAnalytics });",
+			"}",
+		].join("\n"),
+		"src/salesforce/update-settings.js": [
+			"export function getUsageDaysUpdate(settings = [], today = \"2026-03-11\") {",
+			"\tconst lastActiveDay = \"2026-03-10\";",
+			"\tif (lastActiveDay !== today) {",
+			"\t\treturn { usageDays: 2, set: [] };",
+			"\t}",
+			"\treturn { usageDays: 1, set: null };",
+			"}",
+			"",
+			"export async function updateExtensionUsageDays() {",
+			"\tconst usageSettings = [];",
+			"\tconst calculated = getUsageDaysUpdate(usageSettings);",
+			"\tawait sendExtensionMessage({ what: \"set\", set: calculated.set });",
+			"\treturn calculated.usageDays;",
+			"}",
+		].join("\n"),
+		"src/salesforce/once-a-day.js": [
+			"export function executeOncePerDay() {",
+			"\tconst today = \"2026-03-11\";",
+			"\tif (wasCalledToday(today)) {",
+			"\t\treturn;",
+			"\t}",
+			"\tcheckInsertAnalytics();",
+			"\tupdateExtensionUsageDays();",
+			"}",
+		].join("\n"),
+	};
+}
+
+/**
+ * Builds minimal test fixtures from the analyzer's explicit test-title rules.
+ *
+ * @param {Record<string, string[]>} [titleOverrides={}] - Optional file-level title overrides.
+ * @return {Record<string, string>} Fixture test files keyed by relative path.
+ */
+function buildTestFixtures(
+	titleOverrides: Record<string, string[]> = {},
+) {
+	const rules = getInstrumentationRules();
+	const titlesByPath = new Map<string, string[]>();
+	for (const rule of rules) {
+		const existing = titlesByPath.get(rule.tests.path) ?? [];
+		for (const title of rule.tests.requiredTitles) {
+			if (!existing.includes(title)) {
+				existing.push(title);
+			}
+		}
+		titlesByPath.set(rule.tests.path, existing);
+	}
+
+	const files: Record<string, string> = {};
+	for (const [path, titles] of titlesByPath.entries()) {
+		const selectedTitles = titleOverrides[path] ?? titles;
+		files[path] = selectedTitles
+			.map((title) =>
+				`Deno.test("${title}", () => {\n\t// static metrics fixture\n});`,
+			)
+			.join("\n\n");
+	}
+	return files;
+}
+
+/**
+ * Removes a temporary fixture directory.
+ *
+ * @param {string} rootDir - Temporary directory to remove.
+ * @return {Promise<void>} Promise resolved after recursive deletion.
+ */
+async function removeFixtureTree(rootDir: string) {
+	await Deno.remove(rootDir, { recursive: true });
+}
+
+/**
+ * Builds the absolute repository root from this test file location.
+ *
+ * @return {string} Absolute repository root path.
+ */
+function getRepoRootPath() {
+	return new URL("../../", import.meta.url).pathname;
+}
+
+Deno.test("analyzeMetricsCoverage reports covered status when all rule expectations are present", async () => {
+	const rootDir = await writeFixtureTree({
+		...buildCoveredSourceFixtures(),
+		...buildTestFixtures(),
+	});
+	try {
+		const report = await analyzeMetricsCoverage(rootDir);
+		assertEquals(report.totals.targets, 5);
+		assertEquals(report.totals.covered, 5);
+		assertEquals(report.totals.partial, 0);
+		assertEquals(report.totals.uncovered, 0);
+		assertEquals(
+			report.matrix.every((target) => target.status === "covered"),
+			true,
+		);
+		assertGreater(report.matrix[0].sourceLocations.length, 0);
+		assertGreater(report.matrix[0].validatingTests.length, 0);
+	} finally {
+		await removeFixtureTree(rootDir);
+	}
+});
+
+Deno.test("analyzeMetricsCoverage reports partial status when some validating tests are missing", async () => {
+	const analyticsPath = "tests/salesforce/analytics.test.ts";
+	const rootDir = await writeFixtureTree({
+		...buildCoveredSourceFixtures(),
+		...buildTestFixtures({
+			[analyticsPath]: [
+				"syncs opt-out on Firefox consent denial",
+				"inserts beacon for a new Firefox user with consent",
+			],
+		}),
+	});
+	try {
+		const report = await analyzeMetricsCoverage(rootDir);
+		const beaconTarget = report.matrix.find((entry) =>
+			entry.id === "analytics-beacon-insertion"
+		);
+		const consentTarget = report.matrix.find((entry) =>
+			entry.id === "analytics-consent-opt-out"
+		);
+		assertEquals(beaconTarget?.status, "partial");
+		assertEquals(consentTarget?.status, "partial");
+		assertGreater((beaconTarget?.missingTestTitles.length ?? 0), 0);
+		assertGreater((consentTarget?.missingTestTitles.length ?? 0), 0);
+		assertGreater(report.totals.partial, 0);
+	} finally {
+		await removeFixtureTree(rootDir);
+	}
+});
+
+Deno.test("analyzeMetricsCoverage reports uncovered status when source or test files are missing", async () => {
+	const rootDir = await writeFixtureTree({
+		"src/salesforce/analytics.js": "function sendPingToAnalytics() {}",
+	});
+	try {
+		const report = await analyzeMetricsCoverage(rootDir);
+		assertEquals(report.totals.covered, 0);
+		assertEquals(report.totals.uncovered, 5);
+		for (const target of report.matrix) {
+			assertEquals(target.status, "uncovered");
+		}
+	} finally {
+		await removeFixtureTree(rootDir);
+	}
+});
+
+Deno.test("serializeMetricsCoverageReport stays deterministic for identical inputs", async () => {
+	const rootDir = await writeFixtureTree({
+		...buildCoveredSourceFixtures(),
+		...buildTestFixtures(),
+	});
+	try {
+		const report = await analyzeMetricsCoverage(rootDir);
+		const prettyOne = serializeMetricsCoverageReport(report, true);
+		const prettyTwo = serializeMetricsCoverageReport(report, true);
+		const compact = serializeMetricsCoverageReport(report, false);
+		assertEquals(prettyOne, prettyTwo);
+		assertStringIncludes(prettyOne, "\n\t\"totals\"");
+		assertEquals(compact.includes("\n"), false);
+	} finally {
+		await removeFixtureTree(rootDir);
+	}
+});
+
+Deno.test("runCli supports help and compact output flags", async () => {
+	const rootDir = await writeFixtureTree({
+		...buildCoveredSourceFixtures(),
+		...buildTestFixtures(),
+	});
+	const originalConsoleLog = console.log;
+	const outputs: string[] = [];
+	console.log = (...parts: unknown[]) => {
+		outputs.push(parts.map((part) => String(part)).join(" "));
+	};
+	try {
+		const helpCode = await runCli(["--help"]);
+		assertEquals(helpCode, 0);
+		assertStringIncludes(outputs[0], "Usage: deno run --allow-read bin/metrics-coverage.ts");
+
+		outputs.length = 0;
+		const compactCode = await runCli(["--root", rootDir, "--compact"]);
+		assertEquals(compactCode, 0);
+		assertEquals(outputs.length, 1);
+		assertEquals(outputs[0].includes("\n"), false);
+
+		outputs.length = 0;
+		const missingRootValueCode = await runCli(["--root"]);
+		assertEquals(missingRootValueCode, 0);
+		assertEquals(outputs.length, 1);
+	} finally {
+		console.log = originalConsoleLog;
+		await removeFixtureTree(rootDir);
+	}
+});
+
+Deno.test("analyzeMetricsCoverage rethrows non-NotFound read errors", async () => {
+	const rootDir = await Deno.makeTempDir();
+	try {
+		await Deno.mkdir(`${rootDir}/src/salesforce/analytics.js`, {
+			recursive: true,
+		});
+		let errorThrown = false;
+		try {
+			await analyzeMetricsCoverage(rootDir);
+		} catch (error) {
+			errorThrown = error instanceof Error;
+		}
+		assertEquals(errorThrown, true);
+	} finally {
+		await removeFixtureTree(rootDir);
+	}
+});
+
+Deno.test("analyzeMetricsCoverage sorts source locations deterministically for same-line matches", async () => {
+	const rootDir = await writeFixtureTree({
+		"src/salesforce/analytics.js":
+			"function sendPingToAnalytics(){const x='noscript.gif';setDateForPingToday();getTechnicalAndInteractionConsent();const consentGranted=null;syncAnalyticsSetting({id: PREVENT_ANALYTICS, enabled: shouldPreventAnalytics});}",
+		"src/salesforce/update-settings.js":
+			"export function getUsageDaysUpdate(){const lastActiveDay='x';const today='y';if(lastActiveDay !== today){return { usageDays: 1, set: []};}return {usageDays:0,set:null};} export async function updateExtensionUsageDays(){const usageSettings=[];getUsageDaysUpdate(usageSettings);await sendExtensionMessage({what:\"set\"});return 0;}",
+		"src/salesforce/once-a-day.js":
+			"export function executeOncePerDay(){const today='2026-03-11';if(wasCalledToday(today)){return;}checkInsertAnalytics();updateExtensionUsageDays();}",
+		...buildTestFixtures(),
+	});
+	try {
+		const report = await analyzeMetricsCoverage(rootDir);
+		const target = report.matrix.find((entry) =>
+			entry.id === "analytics-beacon-insertion"
+		);
+		const matcherIds = (target?.sourceLocations ?? []).map((location) =>
+			location.matcherId
+		);
+		assertEquals(matcherIds, [
+			"beacon-url",
+			"persist-ping-date",
+			"send-ping-function",
+		]);
+	} finally {
+		await removeFixtureTree(rootDir);
+	}
+});
+
+Deno.test("metrics coverage CLI entrypoint emits JSON when run directly", async () => {
+	const command = new Deno.Command("deno", {
+		args: [
+			"run",
+			"--allow-read",
+			"bin/metrics-coverage.ts",
+			"--root",
+			getRepoRootPath(),
+			"--compact",
+		],
+		cwd: getRepoRootPath(),
+		stdout: "piped",
+		stderr: "piped",
+	});
+	const result = await command.output();
+	const stdout = new TextDecoder().decode(result.stdout);
+	assertEquals(result.code, 0);
+	assertStringIncludes(stdout, "\"totals\"");
+	assertStringIncludes(stdout, "\"matrix\"");
+});


### PR DESCRIPTION
## Summary
- add a Deno CLI static metrics coverage analyzer for telemetry instrumentation paths
- compute a coverage matrix mapping instrumentation targets to source locations and validating tests
- add fixture-based analyzer tests and wire a metrics-coverage task in deno.json
- document scope assumptions, output schema, usage, and known static-analysis limitations

## Validation
- deno lint
- deno test --allow-read --allow-write --allow-run --coverage=coverage/metrics_cov2 tests/bin/metrics-coverage.test.ts
- deno task metrics-coverage --compact