### PR TITLE
feat: add privacy policy consistency checker

### DIFF
--- a/bin/privacy-policy-consistency-check-run.ts
+++ b/bin/privacy-policy-consistency-check-run.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env -S deno run --allow-read
+
+import { runPrivacyPolicyConsistencyChecker } from "./privacy-policy-consistency-check.ts";
+
+Deno.exit(await runPrivacyPolicyConsistencyChecker());

--- a/bin/privacy-policy-consistency-check.ts
+++ b/bin/privacy-policy-consistency-check.ts
@@ -1,0 +1,619 @@
+export type ClaimStatus = "pass" | "fail";
+
+export type RuleCheck = {
+	description: string;
+	passed: boolean;
+};
+
+export type ClaimResult = {
+	id: string;
+	title: string;
+	status: ClaimStatus;
+	summary: string;
+	evidence: string[];
+};
+
+export type CheckerSummary = {
+	totalClaims: number;
+	passedClaims: number;
+	failedClaims: number;
+};
+
+export type CheckerReport = {
+	status: ClaimStatus;
+	summary: CheckerSummary;
+	claims: ClaimResult[];
+};
+
+export type CheckerFilePaths = {
+	policy: string;
+	analytics: string;
+	oncePerDay: string;
+	content: string;
+	constants: string;
+	storage: string;
+	manifest: string;
+	optionsJs: string;
+	optionsHtml: string;
+	functions: string;
+	background: string;
+	themeHandler: string;
+	themeSelector: string;
+	reqPermissions: string;
+};
+
+export type CheckerFiles = {
+	[K in keyof CheckerFilePaths]: string;
+};
+
+export type ReadTextFile = (path: string) => Promise<string>;
+
+export type WriteStdout = (text: string) => void;
+
+export const DEFAULT_CHECKER_FILE_PATHS: CheckerFilePaths = {
+	policy: "docs/PRIVACY_POLICY.md",
+	analytics: "src/salesforce/analytics.js",
+	oncePerDay: "src/salesforce/once-a-day.js",
+	content: "src/salesforce/content.js",
+	constants: "src/core/constants.js",
+	storage: "src/background/storage.js",
+	manifest: "src/manifest/template-manifest.json",
+	optionsJs: "src/settings/options.js",
+	optionsHtml: "src/settings/options.html",
+	functions: "src/core/functions.js",
+	background: "src/background/background.js",
+	themeHandler: "src/action/themeHandler.js",
+	themeSelector: "src/components/theme-selector/theme-selector.js",
+	reqPermissions: "src/action/req_permissions/req_permissions.js",
+};
+
+const POLICY_SYNC_KEYS = [
+	"settings",
+	"settings-tab_generic_style",
+	"settings-tab_org_style",
+	"_locale",
+] as const;
+
+const EXPECTED_LOCAL_STORAGE_KEYS = ["usingTheme", "userTheme", "noPerm"];
+
+/**
+ * Builds a single rule check result.
+ *
+ * @param {string} description Human-readable check description.
+ * @param {boolean} passed Whether the check passed.
+ * @return {RuleCheck} Rule check payload.
+ */
+function createRuleCheck(description: string, passed: boolean): RuleCheck {
+	return { description, passed };
+}
+
+/**
+ * Converts rule checks into a claim result object.
+ *
+ * @param {string} id Stable claim identifier.
+ * @param {string} title Human-readable claim title.
+ * @param {RuleCheck[]} checks Check outcomes for the claim.
+ * @return {ClaimResult} Aggregated claim result.
+ */
+function createClaimResult(
+	id: string,
+	title: string,
+	checks: RuleCheck[],
+): ClaimResult {
+	const failedChecks = checks.filter((check) => !check.passed);
+	const status: ClaimStatus = failedChecks.length === 0 ? "pass" : "fail";
+	const summary = status === "pass"
+		? "All checks passed"
+		: `${failedChecks.length} check(s) failed`;
+	const evidence = checks.map((check) =>
+		`${check.passed ? "pass" : "fail"}: ${check.description}`
+	);
+	return {
+		id,
+		title,
+		status,
+		summary,
+		evidence,
+	};
+}
+
+/**
+ * Finds all markdown backtick tokens in the provided text.
+ *
+ * @param {string} text Source markdown text.
+ * @return {Set<string>} Set of discovered token values.
+ */
+function extractBacktickTokens(text: string): Set<string> {
+	const tokenPattern = /`([^`]+)`/g;
+	const tokens = new Set<string>();
+	for (const match of text.matchAll(tokenPattern)) {
+		tokens.add(match[1]);
+	}
+	return tokens;
+}
+
+/**
+ * Extracts exported string constants from a JavaScript source file.
+ *
+ * @param {string} source JavaScript source code.
+ * @return {Map<string, string>} Exported constant name -> value map.
+ */
+function extractExportedStringConstants(source: string): Map<string, string> {
+	const constantPattern = /export const\s+([A-Z0-9_]+)\s*=\s*"([^"]+)";/g;
+	const constants = new Map<string, string>();
+	for (const match of source.matchAll(constantPattern)) {
+		constants.set(match[1], match[2]);
+	}
+	return constants;
+}
+
+/**
+ * Extracts string literal keys used in localStorage getItem/setItem calls.
+ *
+ * @param {string} source JavaScript source code.
+ * @return {Set<string>} Set of localStorage keys found in the source.
+ */
+function extractLocalStorageKeys(source: string): Set<string> {
+	const localStoragePattern =
+		/localStorage\.(?:getItem|setItem)\(\s*['"]([^'"]+)['"]/g;
+	const keys = new Set<string>();
+	for (const match of source.matchAll(localStoragePattern)) {
+		keys.add(match[1]);
+	}
+	return keys;
+}
+
+/**
+ * Collects localStorage keys from all relevant sources, including constant-based key access.
+ *
+ * @param {CheckerFiles} files Loaded file contents.
+ * @return {Set<string>} Set of all resolved localStorage keys.
+ */
+function collectLocalStorageKeys(files: CheckerFiles): Set<string> {
+	const constants = extractExportedStringConstants(files.constants);
+	const keys = new Set<string>([
+		...extractLocalStorageKeys(files.themeHandler),
+		...extractLocalStorageKeys(files.themeSelector),
+		...extractLocalStorageKeys(files.functions),
+		...extractLocalStorageKeys(files.reqPermissions),
+	]);
+	if (
+		files.functions.includes("DO_NOT_REQUEST_FRAME_PERMISSION") ||
+			files.reqPermissions.includes("DO_NOT_REQUEST_FRAME_PERMISSION")
+	) {
+		const doNotRequestFramePermission = constants.get(
+			"DO_NOT_REQUEST_FRAME_PERMISSION",
+		);
+		if (doNotRequestFramePermission != null) {
+			keys.add(doNotRequestFramePermission);
+		}
+	}
+	return keys;
+}
+
+/**
+ * Returns true when every expected value is present in the provided set.
+ *
+ * @param {Set<string>} values Existing set of values.
+ * @param {readonly string[]} expected Expected values.
+ * @return {boolean} Whether all expected values are present.
+ */
+function hasAllValues(values: Set<string>, expected: readonly string[]): boolean {
+	return expected.every((singleExpectedValue) =>
+		values.has(singleExpectedValue)
+	);
+}
+
+/**
+ * Compares two sets for exact equality.
+ *
+ * @param {Set<string>} left Left-hand set.
+ * @param {Set<string>} right Right-hand set.
+ * @return {boolean} True when both sets contain exactly the same values.
+ */
+function areSetsEqual(left: Set<string>, right: Set<string>): boolean {
+	if (left.size !== right.size) {
+		return false;
+	}
+	for (const value of left) {
+		if (!right.has(value)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/**
+ * Builds the analytics opt-out claim result.
+ *
+ * @param {CheckerFiles} files Loaded file contents.
+ * @return {ClaimResult} Claim evaluation.
+ */
+function evaluateAnalyticsOptOutClaim(files: CheckerFiles): ClaimResult {
+	const policyLower = files.policy.toLowerCase();
+	const settingsAndAnalyticsMention =
+		policyLower.includes("settings") && policyLower.includes("analytics");
+	const checks = [
+		createRuleCheck(
+			"Privacy policy documents analytics opt-out in settings",
+			settingsAndAnalyticsMention &&
+				(policyLower.includes("opt-out") || policyLower.includes("disable analytics")),
+		),
+		createRuleCheck(
+			"Settings UI exposes the prevent_analytics toggle",
+			files.optionsHtml.includes('id="prevent_analytics"'),
+		),
+		createRuleCheck(
+			"Analytics code reads PREVENT_ANALYTICS from stored settings",
+			files.analytics.includes("getSettings(PREVENT_ANALYTICS)"),
+		),
+		createRuleCheck(
+			"Analytics ping is blocked when shouldPreventAnalytics is true",
+			/shouldPreventAnalytics[\s\S]+return;/.test(files.analytics),
+		),
+	];
+	return createClaimResult(
+		"analytics-opt-out",
+		"Analytics Opt-Out Behavior",
+		checks,
+	);
+}
+
+/**
+ * Builds the analytics cadence and path claim result.
+ *
+ * @param {CheckerFiles} files Loaded file contents.
+ * @return {ClaimResult} Claim evaluation.
+ */
+function evaluateAnalyticsCadenceClaim(files: CheckerFiles): ClaimResult {
+	const policyLower = files.policy.toLowerCase();
+	const checks = [
+		createRuleCheck(
+			"Privacy policy states one analytics ping per day",
+			policyLower.includes("1 ping per day"),
+		),
+		createRuleCheck(
+			"Analytics module has same-day suppression logic",
+			files.analytics.includes("hasSentAnalyticsToday"),
+		),
+		createRuleCheck(
+			"Analytics module sends /new-user for first-time ping and / for regular ping",
+			files.analytics.includes('isNewUser ? "/new-user" : "/"'),
+		),
+		createRuleCheck(
+			"Daily orchestrator uses sessionStorage and invokes checkInsertAnalytics",
+			files.oncePerDay.includes("sessionStorage") &&
+				files.oncePerDay.includes("checkInsertAnalytics();"),
+		),
+	];
+	return createClaimResult(
+		"analytics-cadence-path",
+		"Analytics Ping Cadence And Path",
+		checks,
+	);
+}
+
+/**
+ * Builds the analytics endpoint/domain claim result.
+ *
+ * @param {CheckerFiles} files Loaded file contents.
+ * @return {ClaimResult} Claim evaluation.
+ */
+function evaluateAnalyticsEndpointClaim(files: CheckerFiles): ClaimResult {
+	const policyLower = files.policy.toLowerCase();
+	const checks = [
+		createRuleCheck(
+			"Privacy policy references Simple Analytics",
+			policyLower.includes("simple analytics"),
+		),
+		createRuleCheck(
+			"Analytics code targets simpleanalyticscdn.com",
+			files.analytics.includes("simpleanalyticscdn.com"),
+		),
+		createRuleCheck(
+			"Analytics ping path uses /noscript.gif",
+			files.analytics.includes("/noscript.gif"),
+		),
+		createRuleCheck(
+			"Analytics payload uses extension.again.whysalesforce hostname",
+			files.analytics.includes("extension.again.whysalesforce"),
+		),
+	];
+	return createClaimResult(
+		"analytics-endpoint",
+		"Analytics Endpoint And Domain Usage",
+		checks,
+	);
+}
+
+/**
+ * Builds the browser sync storage key claim result.
+ *
+ * @param {CheckerFiles} files Loaded file contents.
+ * @return {ClaimResult} Claim evaluation.
+ */
+function evaluateSyncStorageKeysClaim(files: CheckerFiles): ClaimResult {
+	const policyTokens = extractBacktickTokens(files.policy);
+	const constants = extractExportedStringConstants(files.constants);
+	const hasStyleTemplateDefinitions =
+		/export const GENERIC_TAB_STYLE_KEY\s*=\s*`\$\{SETTINGS_KEY\}-\$\{TAB_GENERIC_STYLE\}`;/
+			.test(files.constants) &&
+		/export const ORG_TAB_STYLE_KEY\s*=\s*`\$\{SETTINGS_KEY\}-\$\{TAB_ORG_STYLE\}`;/
+			.test(files.constants);
+	const checks = [
+		createRuleCheck(
+			"Privacy policy lists all documented sync settings keys",
+			hasAllValues(policyTokens, POLICY_SYNC_KEYS),
+		),
+		createRuleCheck(
+			"Constants define SETTINGS_KEY as settings",
+			constants.get("SETTINGS_KEY") === "settings",
+		),
+		createRuleCheck(
+			"Constants define GENERIC_TAB_STYLE_KEY and ORG_TAB_STYLE_KEY from settings namespace",
+			hasStyleTemplateDefinitions,
+		),
+		createRuleCheck(
+			"Constants define LOCALE_KEY as _locale",
+			constants.get("LOCALE_KEY") === "_locale",
+		),
+		createRuleCheck(
+			"Storage module uses browser sync storage get and set APIs",
+			files.storage.includes("BROWSER.storage.sync.get") &&
+				files.storage.includes("BROWSER.storage.sync.set"),
+		),
+	];
+	return createClaimResult(
+		"storage-sync-keys",
+		"Browser Sync Storage Location And Key Claims",
+		checks,
+	);
+}
+
+/**
+ * Builds the tab data storage claim result.
+ *
+ * @param {CheckerFiles} files Loaded file contents.
+ * @return {ClaimResult} Claim evaluation.
+ */
+function evaluateTabDataStorageClaim(files: CheckerFiles): ClaimResult {
+	const policyLower = files.policy.toLowerCase();
+	const constants = extractExportedStringConstants(files.constants);
+	const checks = [
+		createRuleCheck(
+			"Privacy policy describes tab data in browser sync storage",
+			policyLower.includes("againwhysalesforce") &&
+				policyLower.includes("sync storage") &&
+				!policyLower.includes("nothing is persisted here beyond your current session"),
+		),
+		createRuleCheck(
+			"Constants define WHY_KEY as againWhySalesforce",
+			constants.get("WHY_KEY") === "againWhySalesforce",
+		),
+		createRuleCheck(
+			"Storage module defaults tab read/write operations to WHY_KEY",
+			files.storage.includes("key = WHY_KEY") &&
+				files.storage.includes("bg_setStorage"),
+		),
+	];
+	return createClaimResult(
+		"tab-data-storage",
+		"Tab Data Storage Consistency",
+		checks,
+	);
+}
+
+/**
+ * Builds the localStorage key disclosure claim result.
+ *
+ * @param {CheckerFiles} files Loaded file contents.
+ * @return {ClaimResult} Claim evaluation.
+ */
+function evaluateLocalStorageDisclosureClaim(files: CheckerFiles): ClaimResult {
+	const combinedLocalStorageKeys = collectLocalStorageKeys(files);
+	const expectedKeys = new Set<string>(EXPECTED_LOCAL_STORAGE_KEYS);
+	const policyTokens = extractBacktickTokens(files.policy);
+	const checks = [
+		createRuleCheck(
+			"Privacy policy documents localStorage usage",
+			files.policy.includes("`localStorage`") &&
+				files.policy.toLowerCase().includes("theme"),
+		),
+		createRuleCheck(
+			"Privacy policy explicitly lists all localStorage keys",
+			hasAllValues(policyTokens, EXPECTED_LOCAL_STORAGE_KEYS),
+		),
+		createRuleCheck(
+			"Code localStorage keys exactly match documented keys",
+			areSetsEqual(combinedLocalStorageKeys, expectedKeys),
+		),
+	];
+	return createClaimResult(
+		"localstorage-keys",
+		"LocalStorage Location And Key Claims",
+		checks,
+	);
+}
+
+/**
+ * Parses the template manifest JSON.
+ *
+ * @param {string} manifestSource Raw JSON text.
+ * @return {{ permissions: string[]; optional_permissions: string[]; }} Manifest permission fields.
+ */
+function parseManifestPermissions(manifestSource: string): {
+	permissions: string[];
+	optional_permissions: string[];
+} {
+	const manifest = JSON.parse(manifestSource) as {
+		permissions?: string[];
+		optional_permissions?: string[];
+	};
+	return {
+		permissions: manifest.permissions ?? [],
+		optional_permissions: manifest.optional_permissions ?? [],
+	};
+}
+
+/**
+ * Builds the cookies permission boundary claim result.
+ *
+ * @param {CheckerFiles} files Loaded file contents.
+ * @return {ClaimResult} Claim evaluation.
+ */
+function evaluateCookiePermissionBoundaryClaim(files: CheckerFiles): ClaimResult {
+	const policyLower = files.policy.toLowerCase();
+	const manifestPermissions = parseManifestPermissions(files.manifest);
+	const checks = [
+		createRuleCheck(
+			"Privacy policy includes a least-privilege permission statement",
+			policyLower.includes("least-privilege") &&
+				policyLower.includes("requested at the moment"),
+		),
+		createRuleCheck(
+			"Manifest keeps cookies as optional permission only",
+			!manifestPermissions.permissions.includes("cookies") &&
+				manifestPermissions.optional_permissions.includes("cookies"),
+		),
+		createRuleCheck(
+			"requestCookiesPermission requests cookies with optional host origins",
+			files.functions.includes("requestCookiesPermission") &&
+				files.functions.includes('permissions: ["cookies"]') &&
+				files.functions.includes("EXTENSION_OPTIONAL_HOST_PERM"),
+		),
+		createRuleCheck(
+			"Settings flow requests cookies only for FOLLOW_SF_LANG",
+			files.optionsJs.includes("FOLLOW_SF_LANG") &&
+				files.optionsJs.includes("requestCookiesPermission()"),
+		),
+		createRuleCheck(
+			"Cookie reads happen in the background script",
+			files.background.includes("BROWSER.cookies?.getAll"),
+		),
+	];
+	return createClaimResult(
+		"cookie-permission-boundaries",
+		"Cookie-Permission Usage Boundaries",
+		checks,
+	);
+}
+
+/**
+ * Evaluates all privacy policy consistency claims against loaded file contents.
+ *
+ * @param {CheckerFiles} files Loaded file contents.
+ * @return {CheckerReport} Deterministic checker report.
+ */
+export function evaluatePrivacyPolicyConsistency(files: CheckerFiles): CheckerReport {
+	const claims = [
+		evaluateAnalyticsOptOutClaim(files),
+		evaluateAnalyticsCadenceClaim(files),
+		evaluateAnalyticsEndpointClaim(files),
+		evaluateSyncStorageKeysClaim(files),
+		evaluateTabDataStorageClaim(files),
+		evaluateLocalStorageDisclosureClaim(files),
+		evaluateCookiePermissionBoundaryClaim(files),
+	];
+	const summary = claims.reduce<CheckerSummary>(
+		(accumulator, claim) => {
+			if (claim.status === "pass") {
+				accumulator.passedClaims += 1;
+			} else {
+				accumulator.failedClaims += 1;
+			}
+			return accumulator;
+		},
+		{
+			totalClaims: claims.length,
+			passedClaims: 0,
+			failedClaims: 0,
+		},
+	);
+	return {
+		status: summary.failedClaims === 0 ? "pass" : "fail",
+		summary,
+		claims,
+	};
+}
+
+/**
+ * Renders a checker report as deterministic JSON with trailing newline.
+ *
+ * @param {CheckerReport} report Checker report payload.
+ * @return {string} JSON report representation.
+ */
+export function renderCheckerReport(report: CheckerReport): string {
+	return `${JSON.stringify(report, null, 2)}\n`;
+}
+
+/**
+ * Resolves process exit code from checker report status.
+ *
+ * @param {CheckerReport} report Checker report payload.
+ * @return {number} 0 for pass, 1 for fail.
+ */
+export function getCheckerExitCode(report: CheckerReport): number {
+	return report.status === "pass" ? 0 : 1;
+}
+
+/**
+ * Loads all checker files from disk.
+ *
+ * @param {CheckerFilePaths} [filePaths=DEFAULT_CHECKER_FILE_PATHS] File path map.
+ * @param {ReadTextFile} [readTextFile=Deno.readTextFile] Read function dependency.
+ * @return {Promise<CheckerFiles>} Loaded file contents.
+ */
+export async function loadCheckerFiles(
+	filePaths: CheckerFilePaths = DEFAULT_CHECKER_FILE_PATHS,
+	readTextFile: ReadTextFile = Deno.readTextFile,
+): Promise<CheckerFiles> {
+	return {
+		policy: await readTextFile(filePaths.policy),
+		analytics: await readTextFile(filePaths.analytics),
+		oncePerDay: await readTextFile(filePaths.oncePerDay),
+		content: await readTextFile(filePaths.content),
+		constants: await readTextFile(filePaths.constants),
+		storage: await readTextFile(filePaths.storage),
+		manifest: await readTextFile(filePaths.manifest),
+		optionsJs: await readTextFile(filePaths.optionsJs),
+		optionsHtml: await readTextFile(filePaths.optionsHtml),
+		functions: await readTextFile(filePaths.functions),
+		background: await readTextFile(filePaths.background),
+		themeHandler: await readTextFile(filePaths.themeHandler),
+		themeSelector: await readTextFile(filePaths.themeSelector),
+		reqPermissions: await readTextFile(filePaths.reqPermissions),
+	};
+}
+
+const TEXT_ENCODER = new TextEncoder();
+
+/**
+ * Writes text to process stdout.
+ *
+ * @param {string} text Text to write.
+ */
+function writeToStdout(text: string): void {
+	Deno.stdout.writeSync(TEXT_ENCODER.encode(text));
+}
+
+/**
+ * Executes the checker end-to-end and writes its JSON report to stdout.
+ *
+ * @param {{ filePaths?: CheckerFilePaths; readTextFile?: ReadTextFile; writeStdout?: WriteStdout; }} [dependencies={}] Optional injected dependencies.
+ * @return {Promise<number>} Exit code based on report status.
+ */
+export async function runPrivacyPolicyConsistencyChecker(
+	dependencies: {
+		filePaths?: CheckerFilePaths;
+		readTextFile?: ReadTextFile;
+		writeStdout?: WriteStdout;
+	} = {},
+): Promise<number> {
+	const files = await loadCheckerFiles(
+		dependencies.filePaths ?? DEFAULT_CHECKER_FILE_PATHS,
+		dependencies.readTextFile ?? Deno.readTextFile,
+	);
+	const report = evaluatePrivacyPolicyConsistency(files);
+	(dependencies.writeStdout ?? writeToStdout)(renderCheckerReport(report));
+	return getCheckerExitCode(report);
+}

--- a/deno.json
+++ b/deno.json
@@ -28,6 +28,7 @@
 		"sort": "deno --allow-read --allow-write bin/sort-locales.ts && git add src/_locales/*/messages.json",
 		"locale-check": "deno --allow-read --allow-write bin/find-invalid-variables.ts && deno --allow-read --allow-write bin/missing-locales.ts",
 		"locales": "deno task locale-check && deno task sort",
+		"privacy-policy-check": "deno run --allow-read bin/privacy-policy-consistency-check-run.ts",
 		"bundle": "deno run -A bin/build.ts",
 		"checks": "deno task fmt && deno task lint && deno task test && deno task locales && deno task dev-firefox",
 

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -1,6 +1,6 @@
 # Again, Why Salesforce – Privacy Policy
 
-_Last updated: June 2025_
+_Last updated: March 2026_
 
 **Again, Why Salesforce** is a browser extension that communicates directly between your web browser and the Salesforce page (and Salesforce servers when using the extension in the same language as your Salesforce account). We do **not** collect or store any personal or identifiable information.
 
@@ -19,10 +19,12 @@ _Last updated: June 2025_
 
 ## 2. Local Storage
 
-- We use the browser’s `localStorage` solely to save your **theme preferences** for faster load times.
-- Such preferences are currently used by the popup linked to the extension icon.
-- No other personal data or browsing history is stored.
-- You can clear this by deleting browser history; the extension will continue to function after a page reload.
+- We use the browser’s `localStorage` only for lightweight UI and permission-prompt preferences:
+  - `usingTheme`: current popup theme rendering helper.
+  - `userTheme`: your selected theme preference (`light`, `dark`, or `system`).
+  - `noPerm`: remembers if you dismissed a non-core optional permission prompt.
+- No Salesforce Tab payloads, records, or browsing history are stored in `localStorage`.
+- You can clear these values by deleting browser history/site data; the extension will continue to function after a page reload.
 
 ---
 
@@ -37,11 +39,11 @@ _Last updated: June 2025_
 
 ---
 
-## 4. Tab Data (In-Memory)
+## 4. Tab Data (Browser Storage Sync)
 
-- While running, the extension keeps your **Tab** data in memory (key: `againWhySalesforce`, variable: `WHY_KEY`).
+- Your **Tab** data is stored in browser **sync storage** (key: `againWhySalesforce`, variable: `WHY_KEY`).
 - This powers the Lightning Setup page sidebar, showing your custom Tabs alongside the standard "Home" and "Object Manager".
-- Nothing is persisted here beyond your current session (everything is automatically deleted when you reload the page or when you close your browser tab/window).
+- Data persists across sessions and can sync across devices according to your browser account sync settings.
 
 ---
 

--- a/tests/privacy-policy/privacy-policy-consistency.test.ts
+++ b/tests/privacy-policy/privacy-policy-consistency.test.ts
@@ -1,0 +1,345 @@
+import { assertEquals, assertStringIncludes } from "@std/testing/asserts";
+
+import {
+	type CheckerFilePaths,
+	type CheckerFiles,
+	DEFAULT_CHECKER_FILE_PATHS,
+	evaluatePrivacyPolicyConsistency,
+	getCheckerExitCode,
+	loadCheckerFiles,
+	renderCheckerReport,
+	runPrivacyPolicyConsistencyChecker,
+} from "../../bin/privacy-policy-consistency-check.ts";
+
+/**
+ * Builds a fixture where all checker claims pass.
+ *
+ * @return {CheckerFiles} Fully passing checker fixture.
+ */
+function createPassingFiles(): CheckerFiles {
+	return {
+		policy: `# Privacy
+
+Settings analytics opt-out is available and users can disable analytics.
+We send only 1 ping per day and use Simple Analytics.
+Stored sync keys: \`settings\`, \`settings-tab_generic_style\`, \`settings-tab_org_style\`, \`_locale\`.
+Tab data uses browser sync storage under key \`againWhySalesforce\` and variable \`WHY_KEY\`.
+Local preferences in \`localStorage\` are \`usingTheme\`, \`userTheme\`, and \`noPerm\`.
+Least-Privilege permissions are requested at the moment you use them.
+`,
+		analytics:
+			`getSettings(PREVENT_ANALYTICS); hasSentAnalyticsToday(); isNewUser ? "/new-user" : "/"; simpleanalyticscdn.com; /noscript.gif; extension.again.whysalesforce; if (shouldPreventAnalytics) { return; }`,
+		oncePerDay: `sessionStorage.getItem("today"); checkInsertAnalytics();`,
+		content: `executeOncePerDay();`,
+		constants: `
+export const WHY_KEY = "againWhySalesforce";
+export const LOCALE_KEY = "_locale";
+export const SETTINGS_KEY = "settings";
+export const GENERIC_TAB_STYLE_KEY = \`\${SETTINGS_KEY}-\${TAB_GENERIC_STYLE}\`;
+export const ORG_TAB_STYLE_KEY = \`\${SETTINGS_KEY}-\${TAB_ORG_STYLE}\`;
+export const DO_NOT_REQUEST_FRAME_PERMISSION = "noPerm";
+`,
+		storage:
+			`BROWSER.storage.sync.get([key]); BROWSER.storage.sync.set({ value: 1 }); function bg_setStorage(){} function bg_getStorage(callback, key = WHY_KEY){}`,
+		manifest:
+			`{"permissions":["storage"],"optional_permissions":["cookies"]}`,
+		optionsJs: `if (e.target.value === FOLLOW_SF_LANG) { await requestCookiesPermission(); }`,
+		optionsHtml: `<input id="prevent_analytics" />`,
+		functions:
+			`function requestCookiesPermission(){ return requestPermissions({ permissions: ["cookies"], origins: EXTENSION_OPTIONAL_HOST_PERM }); }
+localStorage.getItem(DO_NOT_REQUEST_FRAME_PERMISSION);`,
+		background: `BROWSER.cookies?.getAll({ name: "sid" });`,
+		themeHandler:
+			`localStorage.setItem("usingTheme", "light"); localStorage.setItem("userTheme", "dark"); localStorage.getItem("userTheme");`,
+		themeSelector: `localStorage.getItem("usingTheme");`,
+		reqPermissions: `localStorage.setItem(DO_NOT_REQUEST_FRAME_PERMISSION, "true");`,
+	};
+}
+
+/**
+ * Returns a fixture with one file overridden.
+ *
+ * @param {Partial<CheckerFiles>} overrides Overridden file contents.
+ * @return {CheckerFiles} Updated fixture.
+ */
+function withOverrides(overrides: Partial<CheckerFiles>): CheckerFiles {
+	return {
+		...createPassingFiles(),
+		...overrides,
+	};
+}
+
+/**
+ * Finds a claim in a report by id.
+ *
+ * @param {{ claims: Array<{ id: string; status: string; }>; }} report Checker report.
+ * @param {string} id Claim identifier.
+ * @return {{ id: string; status: string; }} Claim result.
+ */
+function getClaimStatus(
+	report: { claims: Array<{ id: string; status: string }> },
+	id: string,
+): { id: string; status: string } {
+	const claim = report.claims.find((singleClaim) => singleClaim.id === id);
+	if (claim == null) {
+		throw new Error(`Missing claim: ${id}`);
+	}
+	return claim;
+}
+
+Deno.test("evaluatePrivacyPolicyConsistency returns pass report for matching files", () => {
+	const report = evaluatePrivacyPolicyConsistency(createPassingFiles());
+
+	assertEquals(report.status, "pass");
+	assertEquals(report.summary, {
+		totalClaims: 7,
+		passedClaims: 7,
+		failedClaims: 0,
+	});
+	assertEquals(getCheckerExitCode(report), 0);
+});
+
+Deno.test("analytics claim fails when policy opt-out wording is missing", () => {
+	const report = evaluatePrivacyPolicyConsistency(
+		withOverrides({ policy: "privacy text without analytics controls" }),
+	);
+
+	assertEquals(getClaimStatus(report, "analytics-opt-out").status, "fail");
+	assertEquals(report.status, "fail");
+	assertEquals(getCheckerExitCode(report), 1);
+});
+
+Deno.test("analytics claim accepts disable-analytics wording without explicit opt-out term", () => {
+	const report = evaluatePrivacyPolicyConsistency(
+		withOverrides({
+			policy: createPassingFiles().policy.replace(
+				"opt-out is available and users can disable analytics.",
+				"users can disable analytics.",
+			),
+		}),
+	);
+
+	assertEquals(getClaimStatus(report, "analytics-opt-out").status, "pass");
+});
+
+Deno.test("analytics cadence claim fails when one-ping and path signals are absent", () => {
+	const report = evaluatePrivacyPolicyConsistency(
+		withOverrides({
+			policy: createPassingFiles().policy.replace("1 ping per day", "daily ping"),
+			analytics: "hasSentAnalyticsToday",
+			oncePerDay: "checkInsertAnalytics();",
+		}),
+	);
+
+	assertEquals(getClaimStatus(report, "analytics-cadence-path").status, "fail");
+});
+
+Deno.test("analytics endpoint claim fails when domain markers are missing", () => {
+	const report = evaluatePrivacyPolicyConsistency(
+		withOverrides({
+			policy: createPassingFiles().policy.replace("Simple Analytics", "Analytics"),
+			analytics: "getSettings(PREVENT_ANALYTICS)",
+		}),
+	);
+
+	assertEquals(getClaimStatus(report, "analytics-endpoint").status, "fail");
+});
+
+Deno.test("sync storage key claim fails when constants or policy keys are inconsistent", () => {
+	const report = evaluatePrivacyPolicyConsistency(
+		withOverrides({
+			policy: createPassingFiles().policy.replace("`settings-tab_org_style`", "`settings-tab-org-style`"),
+			constants: createPassingFiles().constants.replace(
+				'export const LOCALE_KEY = "_locale";',
+				'export const LOCALE_KEY = "locale";',
+			),
+		}),
+	);
+
+	assertEquals(getClaimStatus(report, "storage-sync-keys").status, "fail");
+});
+
+Deno.test("tab data claim fails when policy says session-only in-memory", () => {
+	const report = evaluatePrivacyPolicyConsistency(
+		withOverrides({
+			policy:
+				"Tab data key `againWhySalesforce` is in-memory and nothing is persisted here beyond your current session.",
+		}),
+	);
+
+	assertEquals(getClaimStatus(report, "tab-data-storage").status, "fail");
+});
+
+Deno.test("localStorage claim fails when noPerm constant usage is absent", () => {
+	const report = evaluatePrivacyPolicyConsistency(
+		withOverrides({
+			functions: createPassingFiles().functions.replace(
+				"DO_NOT_REQUEST_FRAME_PERMISSION",
+				"FRAME_PERMISSION_FLAG",
+			),
+			reqPermissions: "",
+		}),
+	);
+
+	assertEquals(getClaimStatus(report, "localstorage-keys").status, "fail");
+});
+
+Deno.test("localStorage claim fails when documented and actual key sets diverge with same set size", () => {
+	const report = evaluatePrivacyPolicyConsistency(
+		withOverrides({
+			themeHandler: createPassingFiles().themeHandler.replace(
+				"usingTheme",
+				"usingThemeAlt",
+			),
+			themeSelector: `localStorage.getItem("usingThemeAlt");`,
+		}),
+	);
+
+	assertEquals(getClaimStatus(report, "localstorage-keys").status, "fail");
+});
+
+Deno.test("cookie boundary claim fails when cookies become required permission", () => {
+	const report = evaluatePrivacyPolicyConsistency(
+		withOverrides({
+			manifest: `{"permissions":["storage","cookies"],"optional_permissions":[]}`,
+		}),
+	);
+
+	assertEquals(
+		getClaimStatus(report, "cookie-permission-boundaries").status,
+		"fail",
+	);
+});
+
+Deno.test("cookie boundary claim fails when optional_permissions is missing in manifest", () => {
+	const report = evaluatePrivacyPolicyConsistency(
+		withOverrides({
+			manifest: `{"permissions":["storage"]}`,
+		}),
+	);
+
+	assertEquals(
+		getClaimStatus(report, "cookie-permission-boundaries").status,
+		"fail",
+	);
+});
+
+Deno.test("cookie boundary claim passes when permissions is missing but cookies stay optional", () => {
+	const report = evaluatePrivacyPolicyConsistency(
+		withOverrides({
+			manifest: `{"optional_permissions":["cookies"]}`,
+		}),
+	);
+
+	assertEquals(
+		getClaimStatus(report, "cookie-permission-boundaries").status,
+		"pass",
+	);
+});
+
+Deno.test("renderCheckerReport returns deterministic JSON string with newline", () => {
+	const report = evaluatePrivacyPolicyConsistency(createPassingFiles());
+	const rendered = renderCheckerReport(report);
+
+	assertStringIncludes(rendered, '"status": "pass"');
+	assertEquals(rendered.endsWith("\n"), true);
+});
+
+Deno.test("loadCheckerFiles reads every configured file path", async () => {
+	const filePaths: CheckerFilePaths = {
+		policy: "policy",
+		analytics: "analytics",
+		oncePerDay: "once",
+		content: "content",
+		constants: "constants",
+		storage: "storage",
+		manifest: "manifest",
+		optionsJs: "optionsJs",
+		optionsHtml: "optionsHtml",
+		functions: "functions",
+		background: "background",
+		themeHandler: "themeHandler",
+		themeSelector: "themeSelector",
+		reqPermissions: "reqPermissions",
+	};
+	const readCalls: string[] = [];
+	const loaded = await loadCheckerFiles(
+		filePaths,
+		(path) => {
+			readCalls.push(path);
+			return Promise.resolve(`contents:${path}`);
+		},
+	);
+
+	assertEquals(loaded, {
+		policy: "contents:policy",
+		analytics: "contents:analytics",
+		oncePerDay: "contents:once",
+		content: "contents:content",
+		constants: "contents:constants",
+		storage: "contents:storage",
+		manifest: "contents:manifest",
+		optionsJs: "contents:optionsJs",
+		optionsHtml: "contents:optionsHtml",
+		functions: "contents:functions",
+		background: "contents:background",
+		themeHandler: "contents:themeHandler",
+		themeSelector: "contents:themeSelector",
+		reqPermissions: "contents:reqPermissions",
+	});
+	assertEquals(readCalls, Object.values(filePaths));
+});
+
+Deno.test("runPrivacyPolicyConsistencyChecker writes report and returns exit code", async () => {
+	const writes: string[] = [];
+	const exitCode = await runPrivacyPolicyConsistencyChecker({
+		filePaths: DEFAULT_CHECKER_FILE_PATHS,
+		readTextFile: (path) => {
+			const fixture = createPassingFiles();
+			switch (path) {
+				case DEFAULT_CHECKER_FILE_PATHS.policy:
+					return Promise.resolve(fixture.policy);
+				case DEFAULT_CHECKER_FILE_PATHS.analytics:
+					return Promise.resolve(fixture.analytics);
+				case DEFAULT_CHECKER_FILE_PATHS.oncePerDay:
+					return Promise.resolve(fixture.oncePerDay);
+				case DEFAULT_CHECKER_FILE_PATHS.content:
+					return Promise.resolve(fixture.content);
+				case DEFAULT_CHECKER_FILE_PATHS.constants:
+					return Promise.resolve(fixture.constants);
+				case DEFAULT_CHECKER_FILE_PATHS.storage:
+					return Promise.resolve(fixture.storage);
+				case DEFAULT_CHECKER_FILE_PATHS.manifest:
+					return Promise.resolve(fixture.manifest);
+				case DEFAULT_CHECKER_FILE_PATHS.optionsJs:
+					return Promise.resolve(fixture.optionsJs);
+				case DEFAULT_CHECKER_FILE_PATHS.optionsHtml:
+					return Promise.resolve(fixture.optionsHtml);
+				case DEFAULT_CHECKER_FILE_PATHS.functions:
+					return Promise.resolve(fixture.functions);
+				case DEFAULT_CHECKER_FILE_PATHS.background:
+					return Promise.resolve(fixture.background);
+				case DEFAULT_CHECKER_FILE_PATHS.themeHandler:
+					return Promise.resolve(fixture.themeHandler);
+				case DEFAULT_CHECKER_FILE_PATHS.themeSelector:
+					return Promise.resolve(fixture.themeSelector);
+				case DEFAULT_CHECKER_FILE_PATHS.reqPermissions:
+					return Promise.resolve(fixture.reqPermissions);
+				default:
+					throw new Error(`Unexpected path: ${path}`);
+			}
+		},
+		writeStdout: (value) => {
+			writes.push(value);
+		},
+	});
+
+	assertEquals(exitCode, 0);
+	assertEquals(writes.length, 1);
+	assertStringIncludes(writes[0], '"failedClaims": 0');
+});
+
+Deno.test("runPrivacyPolicyConsistencyChecker supports default dependencies", async () => {
+	const exitCode = await runPrivacyPolicyConsistencyChecker();
+	assertEquals(exitCode, 0);
+});


### PR DESCRIPTION
## Summary
- add a deterministic Deno privacy-policy consistency checker with machine-readable JSON output
- add a dedicated Deno task to run the checker in local/CI flows
- add comprehensive checker tests covering pass/fail paths and report/exit behavior at 100/100/100 for checker code
- align privacy policy storage sections with actual extension behavior (localStorage keys and tab-data sync storage)

## Checker Output Summary
`deno task privacy-policy-check` result:
- status: pass
- totalClaims: 7
- passedClaims: 7
- failedClaims: 0

## Validation
- `deno lint`
- `deno test --allow-read --coverage=coverage/privacy-policy-check tests/privacy-policy/privacy-policy-consistency.test.ts`
  - checker coverage: Branch 100.0 / Function 100.0 / Line 100.0
- `deno task privacy-policy-check`
