### PR TITLE
fix: privacy-policy consistency checker path/runtime issues

### DIFF
--- a/bin/privacy-policy-consistency-check-cli.ts
+++ b/bin/privacy-policy-consistency-check-cli.ts
@@ -1,0 +1,3 @@
+import { runPrivacyPolicyConsistencyCli } from "./privacy-policy-consistency-check.ts";
+
+await runPrivacyPolicyConsistencyCli();

--- a/bin/privacy-policy-consistency-check.ts
+++ b/bin/privacy-policy-consistency-check.ts
@@ -1,0 +1,914 @@
+/**
+ * Privacy-policy consistency checker.
+ *
+ * This checker validates a small, code-verifiable subset of privacy-policy claims
+ * against selected source and config files.
+ */
+
+/**
+ * File paths used by the checker.
+ */
+export interface CheckerFilePaths {
+	policy: string;
+	manifest: string;
+	analytics: string;
+	oncePerDay: string;
+	constants: string;
+	functions: string;
+	themeHandler: string;
+	themeSelector: string;
+	permissionsPage: string;
+	settingsOptions: string;
+}
+
+/**
+ * Text contents loaded from checker file paths.
+ */
+export interface CheckerInputTexts {
+	policy: string;
+	manifest: string;
+	analytics: string;
+	oncePerDay: string;
+	constants: string;
+	functions: string;
+	themeHandler: string;
+	themeSelector: string;
+	permissionsPage: string;
+	settingsOptions: string;
+}
+
+/**
+ * Status for checker report and claim entries.
+ */
+export type CheckStatus = "pass" | "fail";
+
+/**
+ * A single claim evaluation result.
+ */
+export interface ClaimResult {
+	id: string;
+	description: string;
+	status: CheckStatus;
+	policy_evidence: string[];
+	code_evidence: string[];
+	failures: string[];
+}
+
+/**
+ * Final checker output.
+ */
+export interface CheckerReport {
+	checker: string;
+	status: CheckStatus;
+	claims: ClaimResult[];
+	load_errors: string[];
+}
+
+/**
+ * Optional dependencies for programmatic checker execution.
+ */
+export interface CheckerRunOptions {
+	filePaths?: Partial<CheckerFilePaths>;
+	readTextFile?: (path: string) => Promise<string>;
+}
+
+/**
+ * Optional dependencies for CLI runner.
+ */
+export interface CheckerCliOptions extends CheckerRunOptions {
+	writeLine?: (line: string) => void;
+	exit?: (code: number) => void;
+}
+
+interface PolicySignals {
+	hasAnalyticsOptOutClaim: boolean;
+	hasAnalyticsDailyPingClaim: boolean;
+	hasAnalyticsInstallPingClaim: boolean;
+	hasSimpleAnalyticsClaim: boolean;
+	hasStorageClaim: boolean;
+	hasLeastPrivilegeClaim: boolean;
+	hasInteractionPermissionClaim: boolean;
+	storagePolicyKeyMap: Map<string, string>;
+	localStoragePolicyKeys: Set<string>;
+}
+
+interface CodeSignals {
+	hasAnalyticsPreventSetting: boolean;
+	hasAnalyticsPreventGuard: boolean;
+	hasAnalyticsDailyGuard: boolean;
+	hasAnalyticsInstallPath: boolean;
+	hasAnalyticsSimpleHost: boolean;
+	hasAnalyticsQueuePath: boolean;
+	hasAnalyticsHostname: boolean;
+	hasAnalyticsSettingsToggle: boolean;
+	hasOncePerDayGuard: boolean;
+	hasStoragePermission: boolean;
+	hasCookiesInOptionalPermissions: boolean;
+	hasCookiesInRequiredPermissions: boolean;
+	hasOptionalSalesforceHostPermission: boolean;
+	hasCookiePermissionRequestBoundary: boolean;
+	constantKeyMap: Map<string, string>;
+	localStorageKeysInCode: Set<string>;
+}
+
+interface RuleCheck {
+	ok: boolean;
+	evidence: string;
+}
+
+const CHECKER_NAME = "privacy-policy-consistency";
+
+/**
+ * Default checker file paths.
+ */
+export const DEFAULT_CHECKER_FILE_PATHS: CheckerFilePaths = Object.freeze({
+	policy: "docs/PRIVACY_POLICY.md",
+	manifest: "src/manifest.json",
+	analytics: "src/salesforce/analytics.js",
+	oncePerDay: "src/salesforce/once-a-day.js",
+	constants: "src/core/constants.js",
+	functions: "src/core/functions.js",
+	themeHandler: "src/action/themeHandler.js",
+	themeSelector: "src/components/theme-selector/theme-selector.js",
+	permissionsPage: "src/action/req_permissions/req_permissions.js",
+	settingsOptions: "src/settings/options.js",
+});
+
+const CHECKER_FILE_KEYS = [
+	"policy",
+	"manifest",
+	"analytics",
+	"oncePerDay",
+	"constants",
+	"functions",
+	"themeHandler",
+	"themeSelector",
+	"permissionsPage",
+	"settingsOptions",
+] as const;
+
+const STORAGE_VARIABLE_NAMES = [
+	"WHY_KEY",
+	"SETTINGS_KEY",
+	"GENERIC_TAB_STYLE_KEY",
+	"ORG_TAB_STYLE_KEY",
+	"LOCALE_KEY",
+] as const;
+
+const LOCAL_STORAGE_CONSTANTS = ["DO_NOT_REQUEST_FRAME_PERMISSION"] as const;
+const STORAGE_DERIVATION_VARIABLE_NAMES = [
+	"TAB_GENERIC_STYLE",
+	"TAB_ORG_STYLE",
+] as const;
+
+/**
+ * Merges user-provided paths over checker defaults.
+ *
+ * @param {Partial<CheckerFilePaths>} [overrides={}] - Optional file path overrides.
+ * @return {CheckerFilePaths} Resolved file paths.
+ */
+export function resolveCheckerFilePaths(
+	overrides: Partial<CheckerFilePaths> = {},
+): CheckerFilePaths {
+	return {
+		...DEFAULT_CHECKER_FILE_PATHS,
+		...overrides,
+	};
+}
+
+/**
+ * Normalizes a text to lowercase for phrase checks.
+ *
+ * @param {string} value - Raw text.
+ * @return {string} Lowercased text.
+ */
+function normalizeText(value: string): string {
+	return value.toLowerCase();
+}
+
+/**
+ * Safely turns unknown errors into readable messages.
+ *
+ * @param {unknown} err - Thrown error value.
+ * @return {string} Human-readable error message.
+ */
+function getErrorMessage(err: unknown): string {
+	if (err instanceof Error) {
+		return err.message;
+	}
+	return String(err);
+}
+
+/**
+ * Loads checker files and collects non-fatal load errors.
+ *
+ * @param {CheckerFilePaths} filePaths - File paths to read.
+ * @param {(path: string) => Promise<string>} readTextFile - File reader.
+ * @return {Promise<{ inputs: CheckerInputTexts; loadErrors: string[] }>} Loaded texts and load errors.
+ */
+export async function loadCheckerInputs(
+	filePaths: CheckerFilePaths,
+	readTextFile: (path: string) => Promise<string>,
+): Promise<{ inputs: CheckerInputTexts; loadErrors: string[] }> {
+	const loadErrors: string[] = [];
+	const values = await Promise.all(
+		CHECKER_FILE_KEYS.map(async (key) => {
+			const path = filePaths[key];
+			try {
+				return await readTextFile(path);
+			} catch (err) {
+				loadErrors.push(
+					`unable_to_read:${key}:${path}:${getErrorMessage(err)}`,
+				);
+				return "";
+			}
+		}),
+	);
+	const [
+		policy,
+		manifest,
+		analytics,
+		oncePerDay,
+		constants,
+		functions,
+		themeHandler,
+		themeSelector,
+		permissionsPage,
+		settingsOptions,
+	] = values;
+	return {
+		inputs: {
+			policy,
+			manifest,
+			analytics,
+			oncePerDay,
+			constants,
+			functions,
+			themeHandler,
+			themeSelector,
+			permissionsPage,
+			settingsOptions,
+		},
+		loadErrors,
+	};
+}
+
+/**
+ * Extracts the markdown section body for a numbered heading.
+ *
+ * @param {string} markdown - Full markdown document.
+ * @param {number} sectionNumber - Section number to extract.
+ * @return {string} Section text (or empty string).
+ */
+export function extractPolicySection(markdown: string, sectionNumber: number): string {
+	const pattern = new RegExp(
+		`##\\s+${sectionNumber}\\.\\s+[\\s\\S]*?(?=\\n##\\s+\\d+\\.|$)`,
+		"i",
+	);
+	return markdown.match(pattern)?.[0] ?? "";
+}
+
+/**
+ * Extracts backtick-enclosed values from markdown text.
+ *
+ * @param {string} text - Markdown snippet.
+ * @return {string[]} Extracted values.
+ */
+export function extractBacktickValues(text: string): string[] {
+	const values: string[] = [];
+	const pattern = /`([^`]+)`/g;
+	let match = pattern.exec(text);
+	while (match != null) {
+		values.push(match[1]);
+		match = pattern.exec(text);
+	}
+	return values;
+}
+
+/**
+ * Extracts storage key mappings from privacy policy text.
+ *
+ * Expected shape: `key` + `VARIABLE_NAME` from markdown table rows and
+ * the in-memory section sentence for WHY_KEY.
+ *
+ * @param {string} policyText - Full privacy policy text.
+ * @return {Map<string, string>} Map from variable names to key values.
+ */
+export function extractPolicyStorageKeyMap(policyText: string): Map<string, string> {
+	const keyMap = new Map<string, string>();
+	const tablePattern = /\|\s*`([^`]+)`\s*\|\s*`([^`]+)`\s*\|/g;
+	let match = tablePattern.exec(policyText);
+	while (match != null) {
+		const keyValue = match[1].trim();
+		const variableName = match[2].trim();
+		keyMap.set(variableName, keyValue);
+		match = tablePattern.exec(policyText);
+	}
+	const inMemoryPattern = /key:\s*`([^`]+)`\s*,\s*variable:\s*`([^`]+)`/i;
+	const inMemoryMatch = policyText.match(inMemoryPattern);
+	if (inMemoryMatch != null) {
+		keyMap.set(inMemoryMatch[2].trim(), inMemoryMatch[1].trim());
+	}
+	return keyMap;
+}
+
+/**
+ * Extracts policy-level checks and key declarations.
+ *
+ * @param {string} policyText - Full privacy policy markdown.
+ * @return {PolicySignals} Parsed policy signals.
+ */
+export function extractPolicySignals(policyText: string): PolicySignals {
+	const normalized = normalizeText(policyText);
+	const localStorageSection = extractPolicySection(policyText, 2);
+	const localStoragePolicyKeys = new Set(
+		extractBacktickValues(localStorageSection).filter((value) =>
+			value !== "localStorage"
+		),
+	);
+	return {
+		hasAnalyticsOptOutClaim: /opt-?out/.test(normalized) &&
+			/settings/.test(normalized) && /analytics/.test(normalized),
+		hasAnalyticsDailyPingClaim:
+			/1 ping per day/.test(normalized) || /one ping per day/.test(normalized),
+		hasAnalyticsInstallPingClaim:
+			/special ping/.test(normalized) && /install/.test(normalized),
+		hasSimpleAnalyticsClaim: /simple analytics/.test(normalized),
+		hasStorageClaim: /localstorage/.test(normalized) && /theme/.test(normalized),
+		hasLeastPrivilegeClaim: /least-privilege/.test(normalized),
+		hasInteractionPermissionClaim: /requested at the moment you interact/.test(normalized),
+		storagePolicyKeyMap: extractPolicyStorageKeyMap(policyText),
+		localStoragePolicyKeys,
+	};
+}
+
+/**
+ * Extracts selected exported string constants from source text.
+ *
+ * @param {string} sourceText - Source file text.
+ * @param {readonly string[]} constantNames - Constant names to extract.
+ * @return {Map<string, string>} Constant-value mapping.
+ */
+export function extractExportedStringConstants(
+	sourceText: string,
+	constantNames: readonly string[],
+): Map<string, string> {
+	const values = new Map<string, string>();
+	for (const constantName of constantNames) {
+		const pattern = new RegExp(
+			`export\\s+const\\s+${constantName}\\s*=\\s*["']([^"']+)["'];`,
+		);
+		const match = sourceText.match(pattern);
+		if (match != null) {
+			values.set(constantName, match[1]);
+		}
+	}
+	return values;
+}
+
+/**
+ * Resolves one localStorage argument expression into a concrete key.
+ *
+ * @param {string} argument - The first argument expression.
+ * @param {Map<string, string>} constantMap - Constants usable in storage calls.
+ * @return {string | null} Concrete key name or null.
+ */
+export function resolveLocalStorageArgument(
+	argument: string,
+	constantMap: Map<string, string>,
+): string | null {
+	const trimmed = argument.trim();
+	const stringMatch = trimmed.match(/^(["'])([^"']+)\1$/);
+	if (stringMatch != null) {
+		return stringMatch[2];
+	}
+	if (constantMap.has(trimmed)) {
+		return constantMap.get(trimmed) ?? null;
+	}
+	return null;
+}
+
+/**
+ * Extracts localStorage key usage from a source file.
+ *
+ * @param {string} sourceText - Source file text.
+ * @param {Map<string, string>} constantMap - Constants usable in storage calls.
+ * @return {Set<string>} Detected key names.
+ */
+export function extractLocalStorageKeysFromSource(
+	sourceText: string,
+	constantMap: Map<string, string>,
+): Set<string> {
+	const keys = new Set<string>();
+	const pattern = /localStorage\.(?:getItem|setItem)\(\s*([^,\)\n]+)[^\)]*\)/g;
+	let match = pattern.exec(sourceText);
+	while (match != null) {
+		const resolvedKey = resolveLocalStorageArgument(match[1], constantMap);
+		if (resolvedKey != null) {
+			keys.add(resolvedKey);
+		}
+		match = pattern.exec(sourceText);
+	}
+	return keys;
+}
+
+/**
+ * Parses the extension manifest from JSON text.
+ *
+ * @param {string} manifestText - Raw manifest JSON.
+ * @return {{ permissions: string[]; optional_permissions: string[]; optional_host_permissions: string[] }}
+ * Parsed manifest arrays (empty when invalid).
+ */
+export function parseManifestPermissions(manifestText: string): {
+	permissions: string[];
+	optional_permissions: string[];
+	optional_host_permissions: string[];
+} {
+	try {
+		const manifest = JSON.parse(manifestText);
+		return {
+			permissions: Array.isArray(manifest.permissions)
+				? manifest.permissions
+				: [],
+			optional_permissions: Array.isArray(manifest.optional_permissions)
+				? manifest.optional_permissions
+				: [],
+			optional_host_permissions: Array.isArray(manifest.optional_host_permissions)
+				? manifest.optional_host_permissions
+				: [],
+		};
+	} catch {
+		return {
+			permissions: [],
+			optional_permissions: [],
+			optional_host_permissions: [],
+		};
+	}
+}
+
+/**
+ * Extracts code-level checks from loaded files.
+ *
+ * @param {CheckerInputTexts} inputs - Loaded checker inputs.
+ * @return {CodeSignals} Parsed code signals.
+ */
+export function extractCodeSignals(inputs: CheckerInputTexts): CodeSignals {
+	const constantKeyMap = extractExportedStringConstants(
+		inputs.constants,
+		[
+			...STORAGE_VARIABLE_NAMES,
+			...LOCAL_STORAGE_CONSTANTS,
+			...STORAGE_DERIVATION_VARIABLE_NAMES,
+		],
+	);
+	const settingsKey = constantKeyMap.get("SETTINGS_KEY");
+	const genericSuffix = constantKeyMap.get("TAB_GENERIC_STYLE");
+	const orgSuffix = constantKeyMap.get("TAB_ORG_STYLE");
+	if (
+		settingsKey != null &&
+		genericSuffix != null &&
+		/export\s+const\s+GENERIC_TAB_STYLE_KEY\s*=/.test(inputs.constants)
+	) {
+		constantKeyMap.set(
+			"GENERIC_TAB_STYLE_KEY",
+			`${settingsKey}-${genericSuffix}`,
+		);
+	}
+	if (
+		settingsKey != null &&
+		orgSuffix != null &&
+		/export\s+const\s+ORG_TAB_STYLE_KEY\s*=/.test(inputs.constants)
+	) {
+		constantKeyMap.set(
+			"ORG_TAB_STYLE_KEY",
+			`${settingsKey}-${orgSuffix}`,
+		);
+	}
+	const localStorageKeysInCode = new Set<string>();
+	for (
+		const sourceText of [
+			inputs.themeHandler,
+			inputs.themeSelector,
+			inputs.permissionsPage,
+			inputs.functions,
+		]
+	) {
+		for (
+			const localStorageKey of extractLocalStorageKeysFromSource(
+				sourceText,
+				constantKeyMap,
+			)
+		) {
+			localStorageKeysInCode.add(localStorageKey);
+		}
+	}
+	const manifest = parseManifestPermissions(inputs.manifest);
+	const analytics = inputs.analytics;
+	const oncePerDay = inputs.oncePerDay;
+	const functions = inputs.functions;
+	const settingsOptions = inputs.settingsOptions;
+	return {
+		hasAnalyticsPreventSetting: /getSettings\(PREVENT_ANALYTICS\)/.test(
+			analytics,
+		),
+		hasAnalyticsPreventGuard:
+			/shouldPreventAnalytics/.test(analytics) &&
+			/if\s*\([\s\S]*shouldPreventAnalytics[\s\S]*\)\s*\{\s*return;/.test(
+				analytics,
+			),
+		hasAnalyticsDailyGuard:
+			/hasSentAnalyticsToday/.test(analytics) &&
+			/Math\.floor\(/.test(analytics),
+		hasAnalyticsInstallPath: /isNewUser\s*\?\s*"\/new-user"\s*:\s*"\/"/.test(
+			analytics,
+		),
+		hasAnalyticsSimpleHost: /simpleanalyticscdn\.com/.test(analytics),
+		hasAnalyticsQueuePath: /noscript\.gif/.test(analytics),
+		hasAnalyticsHostname: /extension\.again\.whysalesforce/.test(analytics),
+		hasAnalyticsSettingsToggle: /\[PREVENT_ANALYTICS\]/.test(settingsOptions),
+		hasOncePerDayGuard:
+			/wasCalledToday\(today\)/.test(oncePerDay) &&
+			/checkInsertAnalytics\(\)/.test(oncePerDay),
+		hasStoragePermission: manifest.permissions.includes("storage"),
+		hasCookiesInOptionalPermissions:
+			manifest.optional_permissions.includes("cookies"),
+		hasCookiesInRequiredPermissions: manifest.permissions.includes("cookies"),
+		hasOptionalSalesforceHostPermission:
+			manifest.optional_host_permissions.includes("*://*.my.salesforce.com/*"),
+		hasCookiePermissionRequestBoundary:
+			/function\s+requestCookiesPermission\(\)/.test(functions) &&
+			/permissions:\s*\["cookies"\]/.test(functions) &&
+			/origins:\s*EXTENSION_OPTIONAL_HOST_PERM/.test(functions),
+		constantKeyMap,
+		localStorageKeysInCode,
+	};
+}
+
+/**
+ * Builds a pass/fail check object.
+ *
+ * @param {boolean} ok - Whether check passed.
+ * @param {string} evidence - Evidence description.
+ * @return {RuleCheck} Rule check object.
+ */
+export function createRuleCheck(ok: boolean, evidence: string): RuleCheck {
+	return { ok, evidence };
+}
+
+/**
+ * Formats a check entry for report evidence lists.
+ *
+ * @param {RuleCheck} check - Rule check.
+ * @return {string} Formatted evidence entry.
+ */
+export function formatRuleCheck(check: RuleCheck): string {
+	return `${check.ok ? "ok" : "missing"}:${check.evidence}`;
+}
+
+/**
+ * Converts raw checks into a claim result.
+ *
+ * @param {string} id - Claim ID.
+ * @param {string} description - Human-readable claim description.
+ * @param {RuleCheck[]} policyChecks - Policy-side checks.
+ * @param {RuleCheck[]} codeChecks - Code-side checks.
+ * @return {ClaimResult} Evaluated claim result.
+ */
+export function createClaimResult(
+	id: string,
+	description: string,
+	policyChecks: RuleCheck[],
+	codeChecks: RuleCheck[],
+): ClaimResult {
+	const failures = [
+		...policyChecks.filter((check) => !check.ok).map((check) => check.evidence),
+		...codeChecks.filter((check) => !check.ok).map((check) => check.evidence),
+	];
+	return {
+		id,
+		description,
+		status: failures.length === 0 ? "pass" : "fail",
+		policy_evidence: policyChecks.map(formatRuleCheck),
+		code_evidence: codeChecks.map(formatRuleCheck),
+		failures,
+	};
+}
+
+/**
+ * Evaluates analytics opt-out behavior claim.
+ *
+ * @param {PolicySignals} policy - Policy signals.
+ * @param {CodeSignals} code - Code signals.
+ * @return {ClaimResult} Claim result.
+ */
+export function evaluateAnalyticsOptOutClaim(
+	policy: PolicySignals,
+	code: CodeSignals,
+): ClaimResult {
+	return createClaimResult(
+		"analytics_opt_out_behavior",
+		"Analytics can be disabled via settings opt-out behavior.",
+		[
+			createRuleCheck(
+				policy.hasAnalyticsOptOutClaim,
+				"policy mentions analytics opt-out in settings",
+			),
+		],
+		[
+			createRuleCheck(
+				code.hasAnalyticsSettingsToggle,
+				"settings expose PREVENT_ANALYTICS toggle",
+			),
+			createRuleCheck(
+				code.hasAnalyticsPreventSetting,
+				"analytics reads PREVENT_ANALYTICS setting",
+			),
+			createRuleCheck(
+				code.hasAnalyticsPreventGuard,
+				"analytics returns early when prevent flag is active",
+			),
+		],
+	);
+}
+
+/**
+ * Evaluates analytics cadence/install-path claim.
+ *
+ * @param {PolicySignals} policy - Policy signals.
+ * @param {CodeSignals} code - Code signals.
+ * @return {ClaimResult} Claim result.
+ */
+export function evaluateAnalyticsCadenceClaim(
+	policy: PolicySignals,
+	code: CodeSignals,
+): ClaimResult {
+	return createClaimResult(
+		"analytics_ping_cadence_and_path",
+		"Analytics sends one daily ping and a dedicated install path.",
+		[
+			createRuleCheck(
+				policy.hasAnalyticsDailyPingClaim,
+				"policy states one ping per day",
+			),
+			createRuleCheck(
+				policy.hasAnalyticsInstallPingClaim,
+				"policy states special ping for install",
+			),
+		],
+		[
+			createRuleCheck(
+				code.hasAnalyticsDailyGuard,
+				"analytics code contains daily guard",
+			),
+			createRuleCheck(
+				code.hasAnalyticsInstallPath,
+				"analytics code uses /new-user install path",
+			),
+			createRuleCheck(
+				code.hasOncePerDayGuard,
+				"once-a-day wrapper invokes analytics at most once per day",
+			),
+		],
+	);
+}
+
+/**
+ * Evaluates analytics endpoint/domain claim.
+ *
+ * @param {PolicySignals} policy - Policy signals.
+ * @param {CodeSignals} code - Code signals.
+ * @return {ClaimResult} Claim result.
+ */
+export function evaluateAnalyticsEndpointClaim(
+	policy: PolicySignals,
+	code: CodeSignals,
+): ClaimResult {
+	return createClaimResult(
+		"analytics_endpoint_and_domain",
+		"Analytics uses documented Simple Analytics endpoint/domain.",
+		[
+			createRuleCheck(
+				policy.hasSimpleAnalyticsClaim,
+				"policy references Simple Analytics",
+			),
+		],
+		[
+			createRuleCheck(
+				code.hasAnalyticsSimpleHost,
+				"analytics uses simpleanalyticscdn.com",
+			),
+			createRuleCheck(
+				code.hasAnalyticsQueuePath,
+				"analytics uses queue noscript.gif path",
+			),
+			createRuleCheck(
+				code.hasAnalyticsHostname,
+				"analytics sends extension.again.whysalesforce hostname",
+			),
+		],
+	);
+}
+
+/**
+ * Evaluates storage claims, including key mappings and localStorage scope.
+ *
+ * @param {PolicySignals} policy - Policy signals.
+ * @param {CodeSignals} code - Code signals.
+ * @return {ClaimResult} Claim result.
+ */
+export function evaluateStorageClaim(
+	policy: PolicySignals,
+	code: CodeSignals,
+): ClaimResult {
+	const keyChecks: RuleCheck[] = STORAGE_VARIABLE_NAMES.map((variableName) => {
+		const policyValue = policy.storagePolicyKeyMap.get(variableName);
+		const codeValue = code.constantKeyMap.get(variableName);
+		const isMatch = policyValue != null && codeValue != null &&
+			policyValue === codeValue;
+		return createRuleCheck(
+			isMatch,
+			`policy/code key match for ${variableName}`,
+		);
+	});
+	const localStorageCoverageChecks = [
+		...code.localStorageKeysInCode,
+	].map((keyName) =>
+		createRuleCheck(
+			policy.localStoragePolicyKeys.has(keyName),
+			`policy section 2 documents localStorage key ${keyName}`,
+		)
+	);
+	return createClaimResult(
+		"storage_locations_and_keys",
+		"Storage locations and key claims match constants and documented keys.",
+		[
+			createRuleCheck(
+				policy.hasStorageClaim,
+				"policy documents localStorage usage for theme-related preferences",
+			),
+			...keyChecks,
+			...localStorageCoverageChecks,
+		],
+		[
+			createRuleCheck(
+				code.hasStoragePermission,
+				"manifest declares storage permission",
+			),
+		],
+	);
+}
+
+/**
+ * Evaluates cookie-permission boundary claim.
+ *
+ * @param {PolicySignals} policy - Policy signals.
+ * @param {CodeSignals} code - Code signals.
+ * @return {ClaimResult} Claim result.
+ */
+export function evaluateCookiePermissionBoundaryClaim(
+	policy: PolicySignals,
+	code: CodeSignals,
+): ClaimResult {
+	return createClaimResult(
+		"cookie_permission_usage_boundaries",
+		"Cookie access remains optional and requested only on interaction.",
+		[
+			createRuleCheck(
+				policy.hasLeastPrivilegeClaim,
+				"policy includes least-privilege statement",
+			),
+			createRuleCheck(
+				policy.hasInteractionPermissionClaim,
+				"policy states optional permissions are requested on interaction",
+			),
+		],
+		[
+			createRuleCheck(
+				code.hasCookiesInOptionalPermissions,
+				"manifest includes cookies in optional_permissions",
+			),
+			createRuleCheck(
+				!code.hasCookiesInRequiredPermissions,
+				"manifest does not include cookies in required permissions",
+			),
+			createRuleCheck(
+				code.hasOptionalSalesforceHostPermission,
+				"manifest includes optional Salesforce host permission",
+			),
+			createRuleCheck(
+				code.hasCookiePermissionRequestBoundary,
+				"requestCookiesPermission asks for cookies with optional host origins",
+			),
+		],
+	);
+}
+
+/**
+ * Evaluates all configured claims in deterministic order.
+ *
+ * @param {PolicySignals} policy - Policy signals.
+ * @param {CodeSignals} code - Code signals.
+ * @return {ClaimResult[]} Ordered claim results.
+ */
+export function evaluateClaims(
+	policy: PolicySignals,
+	code: CodeSignals,
+): ClaimResult[] {
+	return [
+		evaluateAnalyticsOptOutClaim(policy, code),
+		evaluateAnalyticsCadenceClaim(policy, code),
+		evaluateAnalyticsEndpointClaim(policy, code),
+		evaluateStorageClaim(policy, code),
+		evaluateCookiePermissionBoundaryClaim(policy, code),
+	];
+}
+
+/**
+ * Creates the final checker report.
+ *
+ * @param {ClaimResult[]} claims - Evaluated claims.
+ * @param {string[]} [loadErrors=[]] - File-load errors.
+ * @return {CheckerReport} Final report.
+ */
+export function createCheckerReport(
+	claims: ClaimResult[],
+	loadErrors: string[] = [],
+): CheckerReport {
+	const isPass = loadErrors.length === 0 &&
+		claims.every((claim) => claim.status === "pass");
+	return {
+		checker: CHECKER_NAME,
+		status: isPass ? "pass" : "fail",
+		claims,
+		load_errors: loadErrors,
+	};
+}
+
+/**
+ * Renders report JSON with deterministic pretty formatting.
+ *
+ * @param {CheckerReport} report - Checker report.
+ * @return {string} JSON report text.
+ */
+export function renderReport(report: CheckerReport): string {
+	return JSON.stringify(report, null, 2);
+}
+
+/**
+ * Maps report status to process exit code.
+ *
+ * @param {CheckerReport} report - Checker report.
+ * @return {number} Exit code (0 pass, 1 fail).
+ */
+export function getReportExitCode(report: CheckerReport): number {
+	return report.status === "pass" ? 0 : 1;
+}
+
+/**
+ * Runs the checker with optional dependency injection.
+ *
+ * @param {CheckerRunOptions} [options={}] - Optional runtime dependencies.
+ * @return {Promise<CheckerReport>} Checker report.
+ */
+export async function runPrivacyPolicyConsistencyChecker(
+	options: CheckerRunOptions = {},
+): Promise<CheckerReport> {
+	const resolvedOptions: CheckerRunOptions & {
+		readTextFile: (path: string) => Promise<string>;
+	} = {
+		readTextFile: Deno.readTextFile,
+		...options,
+	};
+	const filePaths = resolveCheckerFilePaths(options.filePaths ?? {});
+	const { inputs, loadErrors } = await loadCheckerInputs(
+		filePaths,
+		resolvedOptions.readTextFile,
+	);
+	const policySignals = extractPolicySignals(inputs.policy);
+	const codeSignals = extractCodeSignals(inputs);
+	const claims = evaluateClaims(policySignals, codeSignals);
+	return createCheckerReport(claims, loadErrors);
+}
+
+/**
+ * Runs checker as a CLI command: prints JSON and exits.
+ *
+ * @param {CheckerCliOptions} [options={}] - Optional runtime dependencies.
+ * @return {Promise<CheckerReport>} Checker report.
+ */
+export async function runPrivacyPolicyConsistencyCli(
+	options: CheckerCliOptions = {},
+): Promise<CheckerReport> {
+	const resolvedOptions: CheckerCliOptions & {
+		writeLine: (line: string) => void;
+		exit: (code: number) => void;
+	} = {
+		writeLine: console.log,
+		exit: Deno.exit,
+		...options,
+	};
+	const report = await runPrivacyPolicyConsistencyChecker(resolvedOptions);
+	resolvedOptions.writeLine(renderReport(report));
+	resolvedOptions.exit(getReportExitCode(report));
+	return report;
+}

--- a/deno.json
+++ b/deno.json
@@ -25,6 +25,7 @@
 
 		"fmt": "deno fmt",
 		"lint": "deno lint",
+		"privacy-policy-check": "deno run --allow-read bin/privacy-policy-consistency-check-cli.ts",
 		"sort": "deno --allow-read --allow-write bin/sort-locales.ts && git add src/_locales/*/messages.json",
 		"locale-check": "deno --allow-read --allow-write bin/find-invalid-variables.ts && deno --allow-read --allow-write bin/missing-locales.ts",
 		"locales": "deno task locale-check && deno task sort",

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -19,8 +19,9 @@ _Last updated: June 2025_
 
 ## 2. Local Storage
 
-- We use the browser’s `localStorage` solely to save your **theme preferences** for faster load times.
-- Such preferences are currently used by the popup linked to the extension icon.
+- We use the browser’s `localStorage` only for local UI preferences and permission-prompt behavior.
+- Theme preferences are saved under `usingTheme` and `userTheme` (used by popup/settings theme toggles).
+- If you choose not to be asked again for optional setup-page access, we store `noPerm` to remember that choice.
 - No other personal data or browsing history is stored.
 - You can clear this by deleting browser history; the extension will continue to function after a page reload.
 

--- a/tests/privacy-policy/privacy-policy-consistency.test.ts
+++ b/tests/privacy-policy/privacy-policy-consistency.test.ts
@@ -1,0 +1,384 @@
+import {
+	assert,
+	assertArrayIncludes,
+	assertEquals,
+} from "@std/testing/asserts";
+import {
+	DEFAULT_CHECKER_FILE_PATHS,
+	extractCodeSignals,
+	extractPolicySection,
+	extractPolicySignals,
+	getReportExitCode,
+	parseManifestPermissions,
+	resolveLocalStorageArgument,
+	renderReport,
+	runPrivacyPolicyConsistencyChecker,
+	runPrivacyPolicyConsistencyCli,
+	type CheckerReport,
+} from "../../bin/privacy-policy-consistency-check.ts";
+
+const CHECKER_PATH_ORDER = [
+	DEFAULT_CHECKER_FILE_PATHS.policy,
+	DEFAULT_CHECKER_FILE_PATHS.manifest,
+	DEFAULT_CHECKER_FILE_PATHS.analytics,
+	DEFAULT_CHECKER_FILE_PATHS.oncePerDay,
+	DEFAULT_CHECKER_FILE_PATHS.constants,
+	DEFAULT_CHECKER_FILE_PATHS.functions,
+	DEFAULT_CHECKER_FILE_PATHS.themeHandler,
+	DEFAULT_CHECKER_FILE_PATHS.themeSelector,
+	DEFAULT_CHECKER_FILE_PATHS.permissionsPage,
+	DEFAULT_CHECKER_FILE_PATHS.settingsOptions,
+];
+
+/**
+ * Builds a minimal fixture set that satisfies all checker rules.
+ *
+ * @return {Record<string, string>} Fixture contents keyed by file path.
+ */
+function createPassingFixtureByPath(): Record<string, string> {
+	const policy = [
+		"# Privacy",
+		"",
+		"## 1. Analytics & User Counting",
+		"- We rely on Simple Analytics to estimate usage.",
+		"- You'll only send 1 ping per day, and a special ping is sent when you install the extension.",
+		"- You can opt-out of analytics in Settings.",
+		"",
+		"## 2. Local Storage",
+		"- We use localStorage for theme behavior.",
+		"- Theme keys: `usingTheme` and `userTheme`.",
+		"- Permission preference key: `noPerm`.",
+		"",
+		"## 3. Browser Storage",
+		"- Browser sync is used.",
+		"",
+		"## 4. Tab Data (In-Memory)",
+		"- While running, tab data stays in memory (key: `againWhySalesforce`, variable: `WHY_KEY`).",
+		"",
+		"## 5. Settings & Decoration Preferences",
+		"| Key                          | Variable Name           | Description |",
+		"| ---------------------------- | ----------------------- | ----------- |",
+		"| `settings`                   | `SETTINGS_KEY`          | settings    |",
+		"| `settings-tab_generic_style` | `GENERIC_TAB_STYLE_KEY` | generic     |",
+		"| `settings-tab_org_style`     | `ORG_TAB_STYLE_KEY`     | org         |",
+		"| `_locale`                    | `LOCALE_KEY`            | locale      |",
+		"",
+		"## 8. Security Measures",
+		"- Least-Privilege applies to all permissions.",
+		"- Optional permissions are requested at the moment you interact with the feature.",
+	].join("\n");
+	const analytics = [
+		"import { PREVENT_ANALYTICS } from \"/core/constants.js\";",
+		"const analyticscdnhost = \"simpleanalyticscdn.com\";",
+		"const queueanalytics = `https://queue.${analyticscdnhost}`;",
+		"function hasSentAnalyticsToday(date) {",
+		"\treturn date != null && Math.floor((Date.now() - new Date(date)) / (1000 * 60 * 60 * 24)) <= 0;",
+		"}",
+		"export async function checkInsertAnalytics() {",
+		"\tconst preventAnalytics = await getSettings(PREVENT_ANALYTICS);",
+		"\tconst isNewUser = preventAnalytics?.date == null;",
+		"\tconst shouldPreventAnalytics = preventAnalytics?.enabled === true;",
+		"\tif (shouldPreventAnalytics || hasSentAnalyticsToday(preventAnalytics?.date)) {",
+		"\t\treturn;",
+		"\t}",
+		"\tconst apiUrl = new URL(`${queueanalytics}/noscript.gif`);",
+		"\tapiUrl.searchParams.set(\"hostname\", \"extension.again.whysalesforce\");",
+		"\tapiUrl.searchParams.set(\"path\", isNewUser ? \"/new-user\" : \"/\");",
+		"}",
+	].join("\n");
+	return {
+		[DEFAULT_CHECKER_FILE_PATHS.policy]: policy,
+		[DEFAULT_CHECKER_FILE_PATHS.manifest]: JSON.stringify({
+			permissions: ["storage"],
+			optional_permissions: ["downloads", "cookies"],
+			optional_host_permissions: ["*://*.my.salesforce.com/*"],
+		}),
+		[DEFAULT_CHECKER_FILE_PATHS.analytics]: analytics,
+		[DEFAULT_CHECKER_FILE_PATHS.oncePerDay]: `
+function wasCalledToday(today) {
+	return sessionStorage.getItem("k") === today;
+}
+export function executeOncePerDay() {
+	const today = "2026-01-01";
+	if (wasCalledToday(today)) {
+		return;
+	}
+	checkInsertAnalytics();
+}`,
+		[DEFAULT_CHECKER_FILE_PATHS.constants]: `
+export const WHY_KEY = "againWhySalesforce";
+export const SETTINGS_KEY = "settings";
+export const TAB_GENERIC_STYLE = "tab_generic_style";
+export const TAB_ORG_STYLE = "tab_org_style";
+export const GENERIC_TAB_STYLE_KEY = \`${"${SETTINGS_KEY}-${TAB_GENERIC_STYLE}"}\`;
+export const ORG_TAB_STYLE_KEY = \`${"${SETTINGS_KEY}-${TAB_ORG_STYLE}"}\`;
+export const LOCALE_KEY = "_locale";
+export const DO_NOT_REQUEST_FRAME_PERMISSION = "noPerm";`,
+		[DEFAULT_CHECKER_FILE_PATHS.functions]: `
+export function requestCookiesPermission() {
+	return requestPermissions({
+		permissions: ["cookies"],
+		origins: EXTENSION_OPTIONAL_HOST_PERM,
+	});
+}
+export function areFramePatternsAllowed() {
+	return localStorage.getItem(DO_NOT_REQUEST_FRAME_PERMISSION) === "true";
+}`,
+		[DEFAULT_CHECKER_FILE_PATHS.themeHandler]: `
+localStorage.setItem("usingTheme", "dark");
+localStorage.setItem("userTheme", "system");`,
+		[DEFAULT_CHECKER_FILE_PATHS.themeSelector]: `
+const current = localStorage.getItem("usingTheme");`,
+		[DEFAULT_CHECKER_FILE_PATHS.permissionsPage]: `
+localStorage.setItem(DO_NOT_REQUEST_FRAME_PERMISSION, "true");`,
+		[DEFAULT_CHECKER_FILE_PATHS.settingsOptions]: `
+const allCheckboxes = {
+	[PREVENT_ANALYTICS]: document.getElementById(PREVENT_ANALYTICS),
+};`,
+	};
+}
+
+/**
+ * Creates a deterministic file reader from fixture data.
+ *
+ * @param {Record<string, string>} fixtureByPath - Fixture map.
+ * @param {string[]} seenPaths - Collector for requested paths.
+ * @return {(path: string) => Promise<string>} Reader function.
+ */
+function createFixtureReader(
+	fixtureByPath: Record<string, string>,
+	seenPaths: string[],
+): (path: string) => Promise<string> {
+	return (path: string): Promise<string> => {
+		seenPaths.push(path);
+		const value = fixtureByPath[path];
+		if (value == null) {
+			return Promise.reject(new Error(`missing fixture for ${path}`));
+		}
+		return Promise.resolve(value);
+	};
+}
+
+/**
+ * Returns one claim status from a report.
+ *
+ * @param {CheckerReport} report - Checker report.
+ * @param {string} claimId - Claim identifier.
+ * @return {string} Claim status.
+ */
+function getClaimStatus(report: CheckerReport, claimId: string): string {
+	const claim = report.claims.find((entry) => entry.id === claimId);
+	assert(claim != null);
+	return claim.status;
+}
+
+Deno.test("runPrivacyPolicyConsistencyChecker supports default dependencies", async () => {
+	const fixtureByPath = createPassingFixtureByPath();
+	const seenPaths: string[] = [];
+	const report = await runPrivacyPolicyConsistencyChecker({
+		readTextFile: createFixtureReader(fixtureByPath, seenPaths),
+	});
+
+	assertEquals(report.status, "pass");
+	assertEquals(
+		seenPaths,
+		CHECKER_PATH_ORDER,
+	);
+	assert(report.claims.every((claim) => claim.status === "pass"));
+});
+
+Deno.test("runPrivacyPolicyConsistencyChecker fails each scoped claim when evidence is missing", async (t) => {
+	const cases: Array<{
+		id: string;
+		mutate: (fixtureByPath: Record<string, string>) => void;
+	}> = [
+		{
+			id: "analytics_opt_out_behavior",
+			mutate: (fixtureByPath) => {
+				fixtureByPath[DEFAULT_CHECKER_FILE_PATHS.settingsOptions] =
+					"const x = {};";
+			},
+		},
+		{
+			id: "analytics_ping_cadence_and_path",
+			mutate: (fixtureByPath) => {
+				fixtureByPath[DEFAULT_CHECKER_FILE_PATHS.analytics] = fixtureByPath[
+					DEFAULT_CHECKER_FILE_PATHS.analytics
+				].replace('"/new-user"', '"/install"');
+			},
+		},
+		{
+			id: "analytics_endpoint_and_domain",
+			mutate: (fixtureByPath) => {
+				fixtureByPath[DEFAULT_CHECKER_FILE_PATHS.analytics] = fixtureByPath[
+					DEFAULT_CHECKER_FILE_PATHS.analytics
+				].replace("simpleanalyticscdn.com", "example.com");
+			},
+		},
+		{
+			id: "storage_locations_and_keys",
+			mutate: (fixtureByPath) => {
+				fixtureByPath[DEFAULT_CHECKER_FILE_PATHS.policy] = fixtureByPath[
+					DEFAULT_CHECKER_FILE_PATHS.policy
+				].replace("`noPerm`", "`differentKey`");
+			},
+		},
+		{
+			id: "cookie_permission_usage_boundaries",
+			mutate: (fixtureByPath) => {
+				fixtureByPath[DEFAULT_CHECKER_FILE_PATHS.manifest] = JSON.stringify({
+					permissions: ["storage", "cookies"],
+					optional_permissions: ["downloads"],
+					optional_host_permissions: ["*://*.my.salesforce.com/*"],
+				});
+			},
+		},
+	];
+
+	for (const testCase of cases) {
+		await t.step(testCase.id, async () => {
+			const fixtureByPath = createPassingFixtureByPath();
+			testCase.mutate(fixtureByPath);
+			const seenPaths: string[] = [];
+			const report = await runPrivacyPolicyConsistencyChecker({
+				readTextFile: createFixtureReader(fixtureByPath, seenPaths),
+			});
+			assertEquals(report.status, "fail");
+			assertEquals(getClaimStatus(report, testCase.id), "fail");
+		});
+	}
+});
+
+Deno.test("runPrivacyPolicyConsistencyChecker captures file-load errors in report", async () => {
+	const fixtureByPath = createPassingFixtureByPath();
+	delete fixtureByPath[DEFAULT_CHECKER_FILE_PATHS.analytics];
+	const seenPaths: string[] = [];
+
+	const report = await runPrivacyPolicyConsistencyChecker({
+		readTextFile: createFixtureReader(fixtureByPath, seenPaths),
+	});
+
+	assertEquals(report.status, "fail");
+	assert(report.load_errors.length > 0);
+	assertArrayIncludes(report.load_errors, [
+		`unable_to_read:analytics:${DEFAULT_CHECKER_FILE_PATHS.analytics}:missing fixture for ${DEFAULT_CHECKER_FILE_PATHS.analytics}`,
+	]);
+});
+
+Deno.test("runPrivacyPolicyConsistencyChecker captures non-Error load failures", async () => {
+	const fixtureByPath = createPassingFixtureByPath();
+	const report = await runPrivacyPolicyConsistencyChecker({
+		readTextFile: (path: string): Promise<string> => {
+			if (path === DEFAULT_CHECKER_FILE_PATHS.analytics) {
+				return Promise.reject("raw-failure");
+			}
+			const value = fixtureByPath[path];
+			if (value == null) {
+				return Promise.reject("missing");
+			}
+			return Promise.resolve(value);
+		},
+	});
+
+	assertEquals(report.status, "fail");
+	assertArrayIncludes(report.load_errors, [
+		`unable_to_read:analytics:${DEFAULT_CHECKER_FILE_PATHS.analytics}:raw-failure`,
+	]);
+});
+
+Deno.test("helper functions cover parse and resolution branches", () => {
+	const parsedManifest = parseManifestPermissions(
+		JSON.stringify({ permissions: ["storage"], optional_permissions: [] }),
+	);
+	assertEquals(parsedManifest.permissions, ["storage"]);
+	assertEquals(parsedManifest.optional_permissions, []);
+	assertEquals(parseManifestPermissions("not-json").permissions, []);
+	const parsedInvalidShape = parseManifestPermissions(
+		JSON.stringify({
+			permissions: "storage",
+			optional_permissions: "cookies",
+			optional_host_permissions: {},
+		}),
+	);
+	assertEquals(parsedInvalidShape.permissions, []);
+	assertEquals(parsedInvalidShape.optional_permissions, []);
+	assertEquals(parsedInvalidShape.optional_host_permissions, []);
+
+	const constantMap = new Map<string, string>([
+		["DO_NOT_REQUEST_FRAME_PERMISSION", "noPerm"],
+		["EMPTY_VALUE", undefined as unknown as string],
+	]);
+	assertEquals(resolveLocalStorageArgument('"usingTheme"', constantMap), "usingTheme");
+	assertEquals(
+		resolveLocalStorageArgument("DO_NOT_REQUEST_FRAME_PERMISSION", constantMap),
+		"noPerm",
+	);
+	assertEquals(resolveLocalStorageArgument("EMPTY_VALUE", constantMap), null);
+	assertEquals(resolveLocalStorageArgument("computeKey()", constantMap), null);
+
+	const codeSignals = extractCodeSignals({
+		policy: "",
+		manifest: "{}",
+		analytics: "",
+		oncePerDay: "",
+		constants: 'export const SETTINGS_KEY = "settings";',
+		functions: "",
+		themeHandler: "",
+		themeSelector: "",
+		permissionsPage: "",
+		settingsOptions: "",
+	});
+	assertEquals(codeSignals.constantKeyMap.get("GENERIC_TAB_STYLE_KEY"), undefined);
+	assertEquals(codeSignals.constantKeyMap.get("ORG_TAB_STYLE_KEY"), undefined);
+});
+
+Deno.test("policy helpers cover fallback section and alternate cadence wording", () => {
+	const noSection = extractPolicySection("# Heading", 2);
+	assertEquals(noSection, "");
+
+	const signals = extractPolicySignals(
+		[
+			"## 1. Analytics & User Counting",
+			"- We rely on Simple Analytics.",
+			"- You can opt-out from settings analytics controls.",
+			"- You will only send one ping per day and a special ping on install.",
+			"## 2. Local Storage",
+			"- localStorage for theme values: `usingTheme`.",
+			"## 8. Security Measures",
+			"- Least-Privilege model.",
+			"- requested at the moment you interact.",
+		].join("\n"),
+	);
+	assertEquals(signals.hasAnalyticsDailyPingClaim, true);
+});
+
+Deno.test("runPrivacyPolicyConsistencyCli writes JSON and exits with matching code", async () => {
+	const fixtureByPath = createPassingFixtureByPath();
+	const outputLines: string[] = [];
+	const exitCodes: number[] = [];
+	const seenPaths: string[] = [];
+
+	const report = await runPrivacyPolicyConsistencyCli({
+		readTextFile: createFixtureReader(fixtureByPath, seenPaths),
+		writeLine: (line) => outputLines.push(line),
+		exit: (code) => exitCodes.push(code),
+	});
+
+	assertEquals(report.status, "pass");
+	assertEquals(exitCodes, [0]);
+	assertEquals(outputLines.length, 1);
+	assertEquals(JSON.parse(outputLines[0]), JSON.parse(renderReport(report)));
+	assertEquals(getReportExitCode(report), 0);
+
+	fixtureByPath[DEFAULT_CHECKER_FILE_PATHS.settingsOptions] = "const x = {};";
+	outputLines.length = 0;
+	exitCodes.length = 0;
+	const failedReport = await runPrivacyPolicyConsistencyCli({
+		readTextFile: createFixtureReader(fixtureByPath, []),
+		writeLine: (line) => outputLines.push(line),
+		exit: (code) => exitCodes.push(code),
+	});
+	assertEquals(failedReport.status, "fail");
+	assertEquals(exitCodes, [1]);
+	assertEquals(getReportExitCode(failedReport), 1);
+});


### PR DESCRIPTION
## Summary
- add a deterministic Deno privacy-policy consistency checker at `bin/privacy-policy-consistency-check.ts`
- add CLI entrypoint `bin/privacy-policy-consistency-check-cli.ts` and `deno task privacy-policy-check`
- add comprehensive tests for pass/fail claim coverage, load-error handling, and CLI exit/report behavior
- update `docs/PRIVACY_POLICY.md` section 2 to document all localStorage keys currently used (`usingTheme`, `userTheme`, `noPerm`)

## Checker output summary
- overall status: `pass`
- claims checked: 5
- passing claims: 5
- failing claims: 0

## Validation
- `deno lint`
- `deno test --allow-read --coverage=coverage/privacy-policy-check tests/privacy-policy/privacy-policy-consistency.test.ts`
  - coverage (`bin/privacy-policy-consistency-check.ts`): `100.0 / 100.0 / 100.0` (branch/function/line)
- `deno task privacy-policy-check`
