### PR TITLE
docs: annotate unclear code purpose

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,3 @@
 This directory contains the documentation about this extension.
+
+- [Why This Exists Hotspots](./WHY_ANNOTATOR.md)

--- a/docs/WHY_ANNOTATOR.md
+++ b/docs/WHY_ANNOTATOR.md
@@ -1,0 +1,32 @@
+# Why This Exists Hotspots
+
+This index points to runtime paths that are easy to misread and now include
+purpose-oriented inline annotations.
+
+## Browser API Selection
+
+- Source: [`src/core/constants.js`](../src/core/constants.js)
+- Why: Edge user agents also contain `chrome`, so detection order must preserve
+  Edge detection before Chromium detection. The `BROWSER` export then
+  normalizes browser API access across Chromium (`chrome`) and Firefox
+  (`browser`).
+- Tests: [`tests/constants.test.ts`](../tests/constants.test.ts)
+
+## Salesforce Host and Cookie Bridge
+
+- Source: [`src/background/background.js`](../src/background/background.js)
+- Why: Salesforce tabs can run on `*.lightning.force.com` or
+  `*.my.salesforce-setup.com`, but API auth cookies are scoped to
+  `*.my.salesforce.com`. The bridge rewrites origins before cookie lookup and
+  API calls so language detection keeps working.
+- Tests: [`tests/background/background.test.ts`](../tests/background/background.test.ts)
+
+## Injected Lightning Navigation Bridge
+
+- Source:
+  [`src/salesforce/lightning-navigation.js`](../src/salesforce/lightning-navigation.js)
+- Why: Aura navigation events are only available in page context, so this
+  script receives same-window `postMessage` requests and triggers Salesforce
+  navigation. A fallback URL keeps navigation usable if Aura calls fail.
+- Tests:
+  [`tests/salesforce/lightning-navigation.test.ts`](../tests/salesforce/lightning-navigation.test.ts)

--- a/src/action/variables.css
+++ b/src/action/variables.css
@@ -1,8 +1,8 @@
 html {
 	--white: #ffffff;
-	--rgbwhite: 255,255,255;
+	--rgbwhite: 255, 255, 255;
 	--black: #000000;
-	--rgbblack: 0,0,0;
+	--rgbblack: 0, 0, 0;
 	--green: #82c4b2;
 	--midgreen: #4ea68f;
 	--darkgreen: #346f5f;

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -330,15 +330,14 @@ export async function bg_setStorage(tobeset, callback = null, key = WHY_KEY) {
 }
 
 /**
- * Determines the Salesforce API host and constructs authorization headers based on the current URL.
- * - Validates the URL against supported Salesforce domains.
- * - Normalizes certain Salesforce subdomains to the main domain.
- * - Retrieves the session ID cookie ("sid") for authentication.
- * - Returns the API host origin and headers needed for authorized requests.
+ * Resolves the Salesforce API host and auth headers for the active org URL.
  *
- * @param {string} currentUrl - The current Salesforce URL.
- * @return {Promise<[string, Object]>|undefined} A promise resolving to a tuple of the API host origin and headers, or undefined if URL is unsupported.
- * @throws {Error} Throws if required authentication cookies are not found.
+ * Why this exists: users navigate on lightning.force.com and
+ * my.salesforce-setup.com, but Salesforce session cookies are scoped to
+ * my.salesforce.com; API calls fail unless we bridge to that host family.
+ *
+ * @param {string} currentUrl - Active Salesforce URL.
+ * @return {Promise<[string, Record<string, string>]|undefined>} API host and headers or undefined for unsupported hosts.
  */
 async function _getAPIHostAndHeaders(currentUrl) {
 	const url = new URL(currentUrl);
@@ -346,6 +345,8 @@ async function _getAPIHostAndHeaders(currentUrl) {
 	if (!isSalesforceHostname(url)) {
 		return;
 	}
+	// Why this exists: REST calls and sid cookie lookup must use
+	// the my.salesforce.com host family even when browsing setup/lightning.
 	if (url.hostname.endsWith(LIGHTNING_FORCE_COM)) {
 		origin = url.origin.replace(LIGHTNING_FORCE_COM, MY_SALESFORCE_COM);
 	} else if (url.hostname.endsWith(MY_SALESFORCE_SETUP_COM)) {

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -9,6 +9,8 @@ function detectBrowser() {
 	if (userAgent.includes("firefox")) {
 		return "firefox";
 	}
+	// Why this exists: Edge user agents include the `chrome` token,
+	// so we must detect Edge before the Chromium branch below.
 	if (userAgent.includes("edg")) {
 		return "edge";
 	}
@@ -27,6 +29,8 @@ export const ISEDGE = BROWSER_NAME === "edge";
 export const ISCHROME = BROWSER_NAME === "chrome" || ISEDGE;
 export const ISFIREFOX = BROWSER_NAME === "firefox";
 export const ISSAFARI = BROWSER_NAME === "safari";
+// Why this exists: Chromium browsers expose extension APIs via `chrome`,
+// while Firefox exposes them via `browser`; this normalizes API access.
 export const BROWSER = ISCHROME ? chrome : browser;
 export const EXTENSION_LABEL = BROWSER.i18n.getMessage("extension_label");
 export const EXTENSION_NAME = "again-why-salesforce";

--- a/src/manifest/template-manifest.json
+++ b/src/manifest/template-manifest.json
@@ -79,9 +79,9 @@
 			"id": "again@why.salesforce",
 			"strict_min_version": "140.0",
 			"data_collection_permissions": {
-                "required": [
-                  "none"
-                ],
+				"required": [
+					"none"
+				],
 				"optional": [
 					"technicalAndInteraction"
 				]

--- a/src/salesforce/favourite-manager.js
+++ b/src/salesforce/favourite-manager.js
@@ -17,7 +17,11 @@ import {
 	WHAT_ADD,
 	WHAT_GET_COMMANDS,
 } from "/core/constants.js";
-import { getSettings, injectStyle, sendExtensionMessage } from "/core/functions.js";
+import {
+	getSettings,
+	injectStyle,
+	sendExtensionMessage,
+} from "/core/functions.js";
 import Tab from "/core/tab.js";
 import { ensureAllTabsAvailability } from "/core/tabContainer.js";
 import ensureTranslatorAvailability from "/core/translator.js";

--- a/src/salesforce/lightning-navigation.js
+++ b/src/salesforce/lightning-navigation.js
@@ -1,4 +1,8 @@
-// This script is injected in Salesforce context and does not share the context with the rest of the scripts in this direcory.
+// Why this exists: this file is injected into the Salesforce page context so
+// it can call Aura APIs (`$A`) that are not reachable from extension scripts.
+// It only accepts explicit same-window postMessage requests from the extension.
+
+const LIGHTNING_NAVIGATION = "lightningNavigation";
 
 /**
  * Handles Lightning navigation based on the provided details.
@@ -31,6 +35,8 @@ function doLightningNavigation(details) {
 		}
 	} catch (error) {
 		console.error(`Navigation failed: ${error.message}`); // do not translate as this will be sent from inside Salesforce
+		// Why this exists: when Aura navigation fails, fallback URL navigation
+		// keeps the extension action usable for the current user flow.
 		if (details.fallbackURL) {
 			open(details.fallbackURL, "_top");
 		}
@@ -43,7 +49,7 @@ addEventListener("message", (e) => {
 		return;
 	}
 	const what = e.data.what;
-	if (what === "lightningNavigation") {
+	if (what === LIGHTNING_NAVIGATION) {
 		doLightningNavigation(e.data);
 	}
 });

--- a/src/salesforce/manageTabs.js
+++ b/src/salesforce/manageTabs.js
@@ -11,7 +11,10 @@ import {
 	TUTORIAL_EVENT_CREATE_MANAGE_TABS_MODAL,
 	TUTORIAL_EVENT_REORDERED_TABS_TABLE,
 } from "/core/constants.js";
-import { getInnerElementFieldBySelector, injectStyle } from "/core/functions.js";
+import {
+	getInnerElementFieldBySelector,
+	injectStyle,
+} from "/core/functions.js";
 import Tab from "/core/tab.js";
 import { ensureAllTabsAvailability, TabContainer } from "/core/tabContainer.js";
 import ensureTranslatorAvailability from "/core/translator.js";

--- a/tests/background/background.test.ts
+++ b/tests/background/background.test.ts
@@ -1,6 +1,6 @@
 import { mockStorage } from "../mocks.test.ts";
 import { assert, assertEquals, assertFalse } from "@std/testing/asserts";
-import { waitForCondition } from "../async.test.ts";
+import { waitForCondition, waitForNextTask } from "../async.test.ts";
 
 import {
 	bg_getCommandLinks,
@@ -12,7 +12,9 @@ import {
 import {
 	BROWSER,
 	CMD_EXPORT_ALL,
+	CMD_OPEN_SETTINGS,
 	CXM_MANAGE_TABS,
+	EXTENSION_GITHUB_LINK,
 	GENERIC_TAB_STYLE_KEY,
 	LOCALE_KEY,
 	NO_RELEASE_NOTES,
@@ -35,6 +37,7 @@ import {
 	WHAT_SET,
 	WHAT_SHOW_EXPORT_MODAL,
 	WHAT_SHOW_IMPORT,
+	WHAT_REQUEST_EXPORT_PERMISSION_TO_OPEN_POPUP,
 	WHAT_START_TUTORIAL,
 	WHAT_THEME,
 	WHY_KEY,
@@ -49,6 +52,14 @@ type EnabledSetting = {
 type CommandLink = {
 	name: string;
 	shortcut: string;
+};
+
+type BrowserTabsWithCreate = typeof BROWSER.tabs & {
+	create?: (details: { url: string }) => Promise<boolean>;
+};
+
+type BrowserRuntimeWithOptionsPage = typeof BROWSER.runtime & {
+	openOptionsPage?: () => void;
 };
 
 /**
@@ -285,6 +296,65 @@ await Deno.test("bg_getSalesforceLanguage behavior", async () => {
 	assertEquals(sflang, "sf-lang-en"); // only for tests, from Salesforce, we'll get the correct language
 });
 
+await Deno.test("bg_getSalesforceLanguage rewrites Salesforce setup hosts for cookie and API access", async () => {
+	const originalFetch = globalThis.fetch;
+	const originalGetAllCookies = BROWSER.cookies.getAll;
+	const cookieRequests: Array<{ domain: string; name: string }> = [];
+	const requestedApiUrls: string[] = [];
+
+	BROWSER.tabs.setMockBrowserTabs([{
+		id: 0,
+		url: "https://mycustomorg.my.salesforce-setup.com/lightning/setup/SetupOneHome/home",
+		active: true,
+		currentWindow: true,
+	}]);
+	BROWSER.cookies.getAll = (which: { domain: string; name: string }) => {
+		cookieRequests.push({ domain: which.domain, name: which.name });
+		return Promise.resolve([{
+			domain: which.domain,
+			name: which.name,
+			value: "setup-sid",
+		}]);
+	};
+	globalThis.fetch = ((path: string | URL) => {
+		requestedApiUrls.push(String(path));
+		return Promise.resolve(
+			new Response(
+				JSON.stringify({ language: "sf-lang-from-setup" }),
+				{ headers: { "Content-Type": "application/json" } },
+			),
+		);
+	}) as typeof fetch;
+
+	try {
+		const language = await bg_getSalesforceLanguage();
+		assertEquals(language, "sf-lang-from-setup");
+		assertEquals(cookieRequests, [{
+			domain: "mycustomorg.my.salesforce.com",
+			name: "sid",
+		}]);
+		assertEquals(requestedApiUrls, [
+			"https://mycustomorg.my.salesforce.com/services/oauth2/userinfo",
+		]);
+	} finally {
+		globalThis.fetch = originalFetch;
+		BROWSER.cookies.getAll = originalGetAllCookies;
+	}
+});
+
+await Deno.test("bg_getSalesforceLanguage falls back to the stored locale when Salesforce cookies are unavailable", async () => {
+	mockStorage[LOCALE_KEY] = "fallback-locale-missing-cookie";
+	BROWSER.tabs.setMockBrowserTabs([{
+		id: 0,
+		url: "https://mycustomorg--sandbox.lightning.force.com",
+		active: true,
+		currentWindow: true,
+	}]);
+	BROWSER.cookies.setMockCookies([]);
+	const sflang = await bg_getSalesforceLanguage();
+	assertEquals(sflang, "fallback-locale-missing-cookie");
+});
+
 await Deno.test("bg_getSalesforceLanguage ignores lookalike non-Salesforce hosts", async () => {
 	mockStorage[LOCALE_KEY] = "fallback-locale";
 	BROWSER.tabs.setMockBrowserTabs([{
@@ -356,10 +426,32 @@ await Deno.test("bg_getCommandLinks behavior", async (t) => {
 });
 
 await Deno.test("background listeners handle runtime, command, and browser events", async () => {
+	const browserTabs = BROWSER.tabs as BrowserTabsWithCreate;
+	const browserRuntime = BROWSER.runtime as BrowserRuntimeWithOptionsPage;
 	const originalSetTimeout = globalThis.setTimeout;
 	const originalSendMessage = BROWSER.tabs.sendMessage;
+	const originalTabsCreate = browserTabs.create;
 	const originalContains = BROWSER.permissions.contains;
+	const originalOpenOptionsPage = browserRuntime.openOptionsPage;
+	const originalDownloads = BROWSER.downloads;
 	const sentMessages: unknown[] = [];
+	const openedTabs: Array<{ url: string }> = [];
+	const downloadsApi = {
+		download: () => Promise.resolve(0),
+		onChanged: {
+			addListener: () => {},
+		},
+	};
+	const settingsWithoutReleaseNotes = [
+		{ enabled: "fr", id: USER_LANGUAGE },
+		{ enabled: false, id: NO_RELEASE_NOTES },
+		{ enabled: false, id: TAB_ADD_FRONT },
+	];
+	const settingsWithReleaseNotesDisabled = [
+		{ enabled: "fr", id: USER_LANGUAGE },
+		{ enabled: true, id: NO_RELEASE_NOTES },
+		{ enabled: false, id: TAB_ADD_FRONT },
+	];
 
 	globalThis.setTimeout = ((handler: TimerHandler) => {
 		if (typeof handler === "function") {
@@ -371,7 +463,13 @@ await Deno.test("background listeners handle runtime, command, and browser event
 		sentMessages.push(message);
 		return Promise.resolve(true);
 	};
+	browserTabs.create = (details: { url: string }) => {
+		openedTabs.push(details);
+		return Promise.resolve(true);
+	};
 	BROWSER.permissions.contains = () => Promise.resolve(true);
+	browserRuntime.openOptionsPage = () => {};
+	BROWSER.downloads = downloadsApi;
 	BROWSER.tabs.setMockBrowserTabs([{
 		id: 1,
 		url: "https://acme.lightning.force.com/lightning/setup/SetupOneHome/home",
@@ -379,11 +477,7 @@ await Deno.test("background listeners handle runtime, command, and browser event
 		currentWindow: true,
 	}]);
 	mockStorage[NO_RELEASE_NOTES] = undefined;
-	mockStorage[SETTINGS_KEY] = [
-		{ enabled: "fr", id: USER_LANGUAGE },
-		{ enabled: false, id: NO_RELEASE_NOTES },
-		{ enabled: false, id: TAB_ADD_FRONT },
-	];
+	mockStorage[SETTINGS_KEY] = settingsWithoutReleaseNotes;
 
 	try {
 		let savedResponse: unknown;
@@ -442,11 +536,27 @@ await Deno.test("background listeners handle runtime, command, and browser event
 			"",
 			() => {},
 		);
+		let exportCheckResponse: null | string | undefined = undefined;
+		BROWSER.runtime.onMessage.triggerMessage(
+			{ what: WHAT_EXPORT_CHECK },
+			"",
+			(response) => {
+				exportCheckResponse = response;
+			},
+		);
+		assertEquals(exportCheckResponse, null);
 		BROWSER.runtime.onMessage.triggerMessage(
 			{ what: WHAT_EXPORT_CHECK },
 			"",
 			() => {},
 		);
+		BROWSER.downloads = undefined;
+		BROWSER.runtime.onMessage.triggerMessage(
+			{ what: WHAT_EXPORT_CHECK },
+			"",
+			() => {},
+		);
+		BROWSER.downloads = downloadsApi;
 		BROWSER.runtime.onMessage.triggerMessage(
 			{ what: WHAT_EXPORT, tabs: [{ label: "x", url: "y" }] },
 			"",
@@ -472,10 +582,62 @@ await Deno.test("background listeners handle runtime, command, and browser event
 		);
 		BROWSER.runtime.onMessage.triggerMessage({}, "", () => {});
 
+		BROWSER.tabs.setMockBrowserTabs([{
+			id: 2,
+			url: "https://example.com/not-setup",
+			active: true,
+			currentWindow: true,
+		}]);
+		BROWSER.commands.onCommand.triggerCommand(CMD_EXPORT_ALL);
+
+		BROWSER.tabs.setMockBrowserTabs([{
+			id: 1,
+			url: "https://acme.lightning.force.com/lightning/setup/SetupOneHome/home",
+			active: true,
+			currentWindow: true,
+		}]);
+		const blockedExportMessages = sentMessages.length;
+		BROWSER.downloads = undefined;
+		BROWSER.commands.onCommand.triggerCommand(CMD_EXPORT_ALL);
+		await waitForCondition(() =>
+			(sentMessages.slice(blockedExportMessages) as Array<{ what?: string }>)
+				.some((message) =>
+				message.what === WHAT_REQUEST_EXPORT_PERMISSION_TO_OPEN_POPUP
+			)
+		);
+		BROWSER.downloads = downloadsApi;
+		BROWSER.commands.onCommand.triggerCommand(CMD_OPEN_SETTINGS);
 		BROWSER.commands.onCommand.triggerCommand(CMD_EXPORT_ALL);
 		BROWSER.commands.onCommand.triggerCommand("unknown-command");
 		await waitForCondition(() => sentMessages.length > 0);
 		assert(sentMessages.length > 0);
+
+		BROWSER.runtime.onInstalled.triggerInstalled({
+			reason: "update",
+			temporary: false,
+		});
+		await waitForCondition(() => openedTabs.length > 0);
+		assertEquals(openedTabs[0].url, `${EXTENSION_GITHUB_LINK}/tree/main/docs/CHANGELOG.md`);
+		BROWSER.runtime.onInstalled.triggerInstalled({
+			reason: "install",
+			temporary: false,
+		});
+		BROWSER.runtime.onInstalled.triggerInstalled({
+			reason: "update",
+			temporary: true,
+		});
+		const originalCreateTab = browserTabs.create;
+		browserTabs.create = () => {
+			throw new Error("should_not_open_changelog");
+		};
+		mockStorage[SETTINGS_KEY] = settingsWithReleaseNotesDisabled;
+		BROWSER.runtime.onInstalled.triggerInstalled({
+			reason: "update",
+			temporary: false,
+		});
+		await waitForNextTask();
+		browserTabs.create = originalCreateTab;
+		mockStorage[SETTINGS_KEY] = settingsWithoutReleaseNotes;
 
 		BROWSER.runtime.onStartup.triggerStartup();
 		BROWSER.tabs.onActivated.triggerActivated({ tabId: 1, windowId: 1 });
@@ -489,12 +651,35 @@ await Deno.test("background listeners handle runtime, command, and browser event
 				currentWindow: true,
 			},
 		);
+		BROWSER.tabs.onUpdated.triggerUpdated(
+			1,
+			{ status: "loading" },
+			{
+				id: 1,
+				url: "https://acme.lightning.force.com/lightning/setup/SetupOneHome/home",
+				active: true,
+				currentWindow: true,
+			},
+		);
+		BROWSER.tabs.onUpdated.triggerUpdated(
+			1,
+			{ status: "complete" },
+			{
+				id: 1,
+				url: "https://acme.lightning.force.com/lightning/setup/SetupOneHome/home",
+				active: false,
+				currentWindow: true,
+			},
+		);
 		BROWSER.windows.onFocusChanged.triggerFocusChanged(1);
 		BROWSER.commands.onChanged.triggerChanged();
 		assert(sentMessages.length > 0);
 	} finally {
 		globalThis.setTimeout = originalSetTimeout;
 		BROWSER.tabs.sendMessage = originalSendMessage;
+		browserTabs.create = originalTabsCreate;
 		BROWSER.permissions.contains = originalContains;
+		browserRuntime.openOptionsPage = originalOpenOptionsPage;
+		BROWSER.downloads = originalDownloads;
 	}
 });

--- a/tests/background/background.test.ts
+++ b/tests/background/background.test.ts
@@ -33,11 +33,11 @@ import {
 	WHAT_GET_SETTINGS,
 	WHAT_GET_SF_LANG,
 	WHAT_GET_STYLE_SETTINGS,
+	WHAT_REQUEST_EXPORT_PERMISSION_TO_OPEN_POPUP,
 	WHAT_SAVED,
 	WHAT_SET,
 	WHAT_SHOW_EXPORT_MODAL,
 	WHAT_SHOW_IMPORT,
-	WHAT_REQUEST_EXPORT_PERMISSION_TO_OPEN_POPUP,
 	WHAT_START_TUTORIAL,
 	WHAT_THEME,
 	WHY_KEY,
@@ -600,10 +600,13 @@ await Deno.test("background listeners handle runtime, command, and browser event
 		BROWSER.downloads = undefined;
 		BROWSER.commands.onCommand.triggerCommand(CMD_EXPORT_ALL);
 		await waitForCondition(() =>
-			(sentMessages.slice(blockedExportMessages) as Array<{ what?: string }>)
+			(sentMessages.slice(blockedExportMessages) as Array<
+				{ what?: string }
+			>)
 				.some((message) =>
-				message.what === WHAT_REQUEST_EXPORT_PERMISSION_TO_OPEN_POPUP
-			)
+					message.what ===
+						WHAT_REQUEST_EXPORT_PERMISSION_TO_OPEN_POPUP
+				)
 		);
 		BROWSER.downloads = downloadsApi;
 		BROWSER.commands.onCommand.triggerCommand(CMD_OPEN_SETTINGS);
@@ -617,7 +620,10 @@ await Deno.test("background listeners handle runtime, command, and browser event
 			temporary: false,
 		});
 		await waitForCondition(() => openedTabs.length > 0);
-		assertEquals(openedTabs[0].url, `${EXTENSION_GITHUB_LINK}/tree/main/docs/CHANGELOG.md`);
+		assertEquals(
+			openedTabs[0].url,
+			`${EXTENSION_GITHUB_LINK}/tree/main/docs/CHANGELOG.md`,
+		);
 		BROWSER.runtime.onInstalled.triggerInstalled({
 			reason: "install",
 			temporary: false,

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -145,8 +145,10 @@ Deno.test("constants prefers the browser API for Firefox and exposes manifest da
 	}
 });
 
-Deno.test("constants detect Edge and still use the chrome API", async () => {
-	const fixture = await loadConstants("Mozilla/5.0 Edg/120.0");
+Deno.test("constants detect Edge before the Chrome token and still use the chrome API", async () => {
+	const fixture = await loadConstants(
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0",
+	);
 	try {
 		const module = fixture.module;
 

--- a/tests/salesforce/lightning-navigation.test.ts
+++ b/tests/salesforce/lightning-navigation.test.ts
@@ -211,7 +211,9 @@ Deno.test("lightning-navigation falls back to open when the Salesforce event API
 		await loadLightningNavigationWithFailingAura();
 
 	try {
-		const registeredListener = listener as LightningNavigationListener | null;
+		const registeredListener = listener as
+			| LightningNavigationListener
+			| null;
 		assertExists(registeredListener);
 		registeredListener({
 			data: {
@@ -238,7 +240,9 @@ Deno.test("lightning-navigation reports failures without opening when no fallbac
 		await loadLightningNavigationWithFailingAura();
 
 	try {
-		const registeredListener = listener as LightningNavigationListener | null;
+		const registeredListener = listener as
+			| LightningNavigationListener
+			| null;
 		assertExists(registeredListener);
 		registeredListener({
 			data: {

--- a/tests/salesforce/lightning-navigation.test.ts
+++ b/tests/salesforce/lightning-navigation.test.ts
@@ -88,6 +88,47 @@ async function loadLightningNavigation() {
 	return { cleanup, errors, listener, opens, records };
 }
 
+/**
+ * Loads the lightning navigation script with a failing Aura API stub.
+ *
+ * @return {Promise<{ cleanup: () => void; errors: string[]; listener: LightningNavigationListener | null; opens: { target: string; url: string; }[]; }>} Listener and captured side effects.
+ */
+async function loadLightningNavigationWithFailingAura() {
+	const errors: string[] = [];
+	const opens: { target: string; url: string }[] = [];
+	let listener: LightningNavigationListener | null = null;
+
+	const { cleanup } = await loadIsolatedModule<
+		Record<string, never>,
+		LightningNavigationDependencies
+	>({
+		modulePath: new URL(
+			"../../src/salesforce/lightning-navigation.js",
+			import.meta.url,
+		),
+		dependencies: {
+			$A: {
+				get: () => {
+					throw new Error("boom");
+				},
+			},
+			addEventListener: (_type, registeredListener) => {
+				listener = registeredListener;
+			},
+			console: {
+				error: (message) => {
+					errors.push(message);
+				},
+			},
+			open: (url, target) => {
+				opens.push({ target, url });
+			},
+		},
+	});
+
+	return { cleanup, errors, listener, opens };
+}
+
 Deno.test("lightning-navigation handles record and URL navigation messages", async () => {
 	const { cleanup, listener, records } = await loadLightningNavigation();
 	const registeredListener = listener as LightningNavigationListener | null;
@@ -166,42 +207,11 @@ Deno.test("lightning-navigation ignores foreign sources and reports invalid type
 });
 
 Deno.test("lightning-navigation falls back to open when the Salesforce event API throws", async () => {
-	const errors: string[] = [];
-	const opens: { target: string; url: string }[] = [];
-	let listener: LightningNavigationListener | null = null;
-
-	const { cleanup } = await loadIsolatedModule<
-		Record<string, never>,
-		LightningNavigationDependencies
-	>({
-		modulePath: new URL(
-			"../../src/salesforce/lightning-navigation.js",
-			import.meta.url,
-		),
-		dependencies: {
-			$A: {
-				get: () => {
-					throw new Error("boom");
-				},
-			},
-			addEventListener: (_type, registeredListener) => {
-				listener = registeredListener;
-			},
-			console: {
-				error: (message) => {
-					errors.push(message);
-				},
-			},
-			open: (url, target) => {
-				opens.push({ target, url });
-			},
-		},
-	});
+	const { cleanup, errors, listener, opens } =
+		await loadLightningNavigationWithFailingAura();
 
 	try {
-		const registeredListener = listener as
-			| LightningNavigationListener
-			| null;
+		const registeredListener = listener as LightningNavigationListener | null;
 		assertExists(registeredListener);
 		registeredListener({
 			data: {
@@ -217,6 +227,29 @@ Deno.test("lightning-navigation falls back to open when the Salesforce event API
 			target: "_top",
 			url: "https://example.com/fallback",
 		}]);
+		assertEquals(errors, ["Navigation failed: boom"]);
+	} finally {
+		cleanup();
+	}
+});
+
+Deno.test("lightning-navigation reports failures without opening when no fallback URL is provided", async () => {
+	const { cleanup, errors, listener, opens } =
+		await loadLightningNavigationWithFailingAura();
+
+	try {
+		const registeredListener = listener as LightningNavigationListener | null;
+		assertExists(registeredListener);
+		registeredListener({
+			data: {
+				navigationType: "url",
+				url: "/broken",
+				what: "lightningNavigation",
+			},
+			source: globalThis,
+		});
+
+		assertEquals(opens, []);
 		assertEquals(errors, ["Navigation failed: boom"]);
 	} finally {
 		cleanup();


### PR DESCRIPTION
## Summary
- annotate opaque runtime hotspots with `Why this exists` rationale in constants detection, Salesforce setup host rewriting, and Lightning navigation bridge paths
- add `docs/WHY_ANNOTATOR.md` and link it from `docs/README.md` as a centralized hotspot index
- expand targeted tests for constants browser ordering, Salesforce host/cookie derivation, Lightning navigation fallback behavior, and background listener branches
- replace non-compliant `await Promise.resolve()` test wait with `waitForNextTask()` and remove newly introduced `unknown` typings in the touched test code

## Verification
- `deno lint`
- `deno test --allow-read tests/constants.test.ts tests/background/background.test.ts tests/salesforce/lightning-navigation.test.ts`
- `deno test --allow-read --coverage=coverage tests/constants.test.ts tests/background/background.test.ts tests/salesforce/lightning-navigation.test.ts`
- `deno test --allow-read --coverage=coverage tests`
- `deno coverage coverage`
