### PR TITLE
feat: add roadmap entropy detector

### DIFF
--- a/bin/roadmap-entropy-detector.ts
+++ b/bin/roadmap-entropy-detector.ts
@@ -1,0 +1,651 @@
+#!/usr/bin/env -S deno run --allow-read
+
+const DEFAULT_SCOPE_THRESHOLD = 0.1;
+const DEFAULT_DRIFT_DAYS_THRESHOLD = 0;
+const DEFAULT_MAX_CREEP = 0;
+const DEFAULT_MAX_DRIFT = 0;
+const DEFAULT_MAX_ENTROPY = 0;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const COMPLETE_STATUSES = new Set(["done", "completed", "closed", "shipped"]);
+
+const ERROR_PREFIX = "error";
+const ALERT_STATUS = "alert";
+const OK_STATUS = "ok";
+
+type JsonRecord = Record<string, unknown>;
+
+type SnapshotItem = {
+	id: string;
+	status: string;
+	targetDate: string;
+	targetEpochDay: number;
+	scopeSize: number;
+};
+
+type RoadmapSnapshot = {
+	items: SnapshotItem[];
+};
+
+type ScopeCreepFinding = {
+	type: "new_item" | "scope_increase";
+	id: string;
+	baselineScope: number;
+	currentScope: number;
+	scopeDelta: number;
+	scopeGrowthRatio: number;
+};
+
+type DriftFinding = {
+	type: "target_slip" | "overdue_incomplete";
+	id: string;
+	status: string;
+	baselineTargetDate: string;
+	currentTargetDate: string;
+	slipDays: number;
+	overdueDays: number;
+};
+
+type DetectorThresholds = {
+	scopeThreshold: number;
+	driftDaysThreshold: number;
+	maxCreep: number;
+	maxDrift: number;
+	maxEntropy: number;
+};
+
+type DetectorResult = {
+	status: "ok" | "alert";
+	meta: {
+		today: string;
+	};
+	thresholds: DetectorThresholds;
+	summary: {
+		baselineItemCount: number;
+		currentItemCount: number;
+		creepCount: number;
+		driftCount: number;
+		entropyScore: number;
+	};
+	findings: {
+		scopeCreep: ScopeCreepFinding[];
+		scheduleDrift: DriftFinding[];
+	};
+	gates: {
+		creepExceeded: boolean;
+		driftExceeded: boolean;
+		entropyExceeded: boolean;
+	};
+};
+
+type CliConfig = {
+	baselinePath: string;
+	currentPath: string;
+	today: string;
+	thresholds: DetectorThresholds;
+};
+
+type CliIo = {
+	args: string[];
+	readTextFile: (path: string) => Promise<string>;
+	writeStdout: (text: string) => void;
+	writeStderr: (text: string) => void;
+	now: () => Date;
+};
+
+/**
+ * Returns true when the value is a plain object.
+ *
+ * @param {unknown} value Value to inspect.
+ * @returns {boolean} True when value is a JSON-like object.
+ */
+function isRecord(value: unknown): value is JsonRecord {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Parses a YYYY-MM-DD date and returns its UTC epoch-day value.
+ *
+ * @param {string} dateString Date string to parse.
+ * @param {string} label Label used in error messages.
+ * @returns {number} UTC epoch-day.
+ */
+export function toEpochDay(dateString: string, label: string): number {
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(dateString)) {
+		throw new Error(`${label} must be in YYYY-MM-DD format.`);
+	}
+	const [yearText, monthText, dayText] = dateString.split("-");
+	const year = Number(yearText);
+	const month = Number(monthText);
+	const day = Number(dayText);
+	const timestamp = Date.UTC(year, month - 1, day);
+	const parsed = new Date(timestamp);
+	if (
+		parsed.getUTCFullYear() !== year ||
+		parsed.getUTCMonth() !== month - 1 ||
+		parsed.getUTCDate() !== day
+	) {
+		throw new Error(`${label} is not a valid calendar date.`);
+	}
+	return Math.floor(timestamp / MS_PER_DAY);
+}
+
+/**
+ * Formats an epoch-day back to YYYY-MM-DD.
+ *
+ * @param {number} epochDay UTC epoch-day.
+ * @returns {string} Date string.
+ */
+function fromEpochDay(epochDay: number): string {
+	return new Date(epochDay * MS_PER_DAY).toISOString().slice(0, 10);
+}
+
+/**
+ * Parses a non-negative number argument.
+ *
+ * @param {string} raw Raw value from CLI arguments.
+ * @param {string} label Option label for errors.
+ * @returns {number} Parsed non-negative number.
+ */
+function parseNonNegativeNumber(raw: string, label: string): number {
+	const parsed = Number(raw);
+	if (!Number.isFinite(parsed) || parsed < 0) {
+		throw new Error(`${label} must be a non-negative number.`);
+	}
+	return parsed;
+}
+
+/**
+ * Parses a non-negative integer argument.
+ *
+ * @param {string} raw Raw value from CLI arguments.
+ * @param {string} label Option label for errors.
+ * @returns {number} Parsed non-negative integer.
+ */
+function parseNonNegativeInteger(raw: string, label: string): number {
+	const parsed = parseNonNegativeNumber(raw, label);
+	if (!Number.isInteger(parsed)) {
+		throw new Error(`${label} must be a non-negative integer.`);
+	}
+	return parsed;
+}
+
+/**
+ * Reads the next argument value from an argument vector.
+ *
+ * @param {string[]} args Full argument array.
+ * @param {number} index Index of the current option.
+ * @param {string} option Option name for errors.
+ * @returns {{ value: string; nextIndex: number }} Parsed value and new index.
+ */
+function readOptionValue(args: string[], index: number, option: string) {
+	const value = args[index + 1];
+	if (value == null || value.startsWith("--")) {
+		throw new Error(`${option} requires a value.`);
+	}
+	return { value, nextIndex: index + 1 };
+}
+
+/**
+ * Builds the CLI usage output.
+ *
+ * @returns {string} Help text.
+ */
+export function getUsage(): string {
+	return [
+		"Roadmap Entropy Detector",
+		"",
+		"Usage:",
+		"  deno run --allow-read bin/roadmap-entropy-detector.ts --baseline <path> --current <path> [options]",
+		"",
+		"Options:",
+		"  --baseline <path>            Baseline roadmap JSON file (required)",
+		"  --current <path>             Current roadmap JSON file (required)",
+		"  --scope-threshold <number>   Scope growth ratio threshold (default: 0.1)",
+		"  --drift-days-threshold <n>   Allowed target-date slip in days (default: 0)",
+		"  --max-creep <n>              Maximum allowed creep findings (default: 0)",
+		"  --max-drift <n>              Maximum allowed drift findings (default: 0)",
+		"  --max-entropy <number>       Maximum allowed entropy score (default: 0)",
+		"  --today <YYYY-MM-DD>         Override the reference date for overdue checks",
+		"  --help                       Show this help",
+	].join("\n");
+}
+
+/**
+ * Parses CLI arguments into a detector configuration.
+ *
+ * @param {string[]} args Raw CLI arguments.
+ * @param {Date} nowDate Reference date used when --today is omitted.
+ * @returns {CliConfig} Parsed configuration.
+ */
+export function parseArgs(args: string[], nowDate: Date): CliConfig {
+	let baselinePath = "";
+	let currentPath = "";
+	let scopeThreshold = DEFAULT_SCOPE_THRESHOLD;
+	let driftDaysThreshold = DEFAULT_DRIFT_DAYS_THRESHOLD;
+	let maxCreep = DEFAULT_MAX_CREEP;
+	let maxDrift = DEFAULT_MAX_DRIFT;
+	let maxEntropy = DEFAULT_MAX_ENTROPY;
+	let today = nowDate.toISOString().slice(0, 10);
+
+	for (let index = 0; index < args.length; index += 1) {
+		const arg = args[index];
+		switch (arg) {
+			case "--help":
+				throw getUsage();
+			case "--baseline": {
+				const option = readOptionValue(args, index, "--baseline");
+				baselinePath = option.value;
+				index = option.nextIndex;
+				break;
+			}
+			case "--current": {
+				const option = readOptionValue(args, index, "--current");
+				currentPath = option.value;
+				index = option.nextIndex;
+				break;
+			}
+			case "--scope-threshold": {
+				const option = readOptionValue(args, index, "--scope-threshold");
+				scopeThreshold = parseNonNegativeNumber(
+					option.value,
+					"--scope-threshold",
+				);
+				index = option.nextIndex;
+				break;
+			}
+			case "--drift-days-threshold": {
+				const option = readOptionValue(
+					args,
+					index,
+					"--drift-days-threshold",
+				);
+				driftDaysThreshold = parseNonNegativeInteger(
+					option.value,
+					"--drift-days-threshold",
+				);
+				index = option.nextIndex;
+				break;
+			}
+			case "--max-creep": {
+				const option = readOptionValue(args, index, "--max-creep");
+				maxCreep = parseNonNegativeInteger(option.value, "--max-creep");
+				index = option.nextIndex;
+				break;
+			}
+			case "--max-drift": {
+				const option = readOptionValue(args, index, "--max-drift");
+				maxDrift = parseNonNegativeInteger(option.value, "--max-drift");
+				index = option.nextIndex;
+				break;
+			}
+			case "--max-entropy": {
+				const option = readOptionValue(args, index, "--max-entropy");
+				maxEntropy = parseNonNegativeNumber(option.value, "--max-entropy");
+				index = option.nextIndex;
+				break;
+			}
+			case "--today": {
+				const option = readOptionValue(args, index, "--today");
+				toEpochDay(option.value, "--today");
+				today = option.value;
+				index = option.nextIndex;
+				break;
+			}
+			default:
+				throw new Error(`Unknown option: ${arg}`);
+		}
+	}
+
+	if (!baselinePath) {
+		throw new Error("--baseline is required.");
+	}
+	if (!currentPath) {
+		throw new Error("--current is required.");
+	}
+
+	return {
+		baselinePath,
+		currentPath,
+		today,
+		thresholds: {
+			scopeThreshold,
+			driftDaysThreshold,
+			maxCreep,
+			maxDrift,
+			maxEntropy,
+		},
+	};
+}
+
+/**
+ * Converts a parsed item into a canonical snapshot item.
+ *
+ * @param {unknown} rawItem Parsed item value.
+ * @param {string} snapshotLabel Label for error reporting.
+ * @param {number} index Item index.
+ * @returns {SnapshotItem} Canonical snapshot item.
+ */
+function parseSnapshotItem(
+	rawItem: unknown,
+	snapshotLabel: string,
+	index: number,
+): SnapshotItem {
+	if (!isRecord(rawItem)) {
+		throw new Error(`${snapshotLabel}.items[${index}] must be an object.`);
+	}
+
+	const id = rawItem.id;
+	if (typeof id !== "string" || id.trim() === "") {
+		throw new Error(`${snapshotLabel}.items[${index}].id must be a non-empty string.`);
+	}
+
+	const status = rawItem.status;
+	if (typeof status !== "string" || status.trim() === "") {
+		throw new Error(`${snapshotLabel}.items[${index}].status must be a non-empty string.`);
+	}
+
+	const targetDate = rawItem.targetDate;
+	if (typeof targetDate !== "string") {
+		throw new Error(`${snapshotLabel}.items[${index}].targetDate must be a string in YYYY-MM-DD format.`);
+	}
+	const targetEpochDay = toEpochDay(targetDate, `${snapshotLabel}.items[${index}].targetDate`);
+
+	const scopePoints = rawItem.scopePoints;
+	const tasks = rawItem.tasks;
+	let scopeSize = 0;
+	if (typeof scopePoints === "number") {
+		if (!Number.isFinite(scopePoints) || scopePoints < 0) {
+			throw new Error(`${snapshotLabel}.items[${index}].scopePoints must be a non-negative number when provided.`);
+		}
+		scopeSize = scopePoints;
+	} else if (Array.isArray(tasks)) {
+		scopeSize = tasks.length;
+	} else {
+		throw new Error(`${snapshotLabel}.items[${index}] must include scopePoints or tasks.`);
+	}
+
+	return {
+		id,
+		status,
+		targetDate,
+		targetEpochDay,
+		scopeSize,
+	};
+}
+
+/**
+ * Validates a parsed roadmap snapshot value.
+ *
+ * @param {unknown} parsed Parsed JSON value.
+ * @param {string} snapshotLabel Label for error reporting.
+ * @returns {RoadmapSnapshot} Validated snapshot.
+ */
+export function validateSnapshot(
+	parsed: unknown,
+	snapshotLabel: string,
+): RoadmapSnapshot {
+	if (!isRecord(parsed)) {
+		throw new Error(`${snapshotLabel} must be a JSON object.`);
+	}
+	if (!Array.isArray(parsed.items)) {
+		throw new Error(`${snapshotLabel}.items must be an array.`);
+	}
+
+	const uniqueIds = new Set<string>();
+	const items = parsed.items.map((item, index) => {
+		const parsedItem = parseSnapshotItem(item, snapshotLabel, index);
+		if (uniqueIds.has(parsedItem.id)) {
+			throw new Error(`${snapshotLabel}.items contains a duplicate id: ${parsedItem.id}`);
+		}
+		uniqueIds.add(parsedItem.id);
+		return parsedItem;
+	});
+
+	return { items };
+}
+
+/**
+ * Computes a normalized growth ratio from baseline and current scope values.
+ *
+ * @param {number} baselineScope Baseline scope size.
+ * @param {number} currentScope Current scope size.
+ * @returns {number} Scope growth ratio.
+ */
+export function computeScopeGrowthRatio(
+	baselineScope: number,
+	currentScope: number,
+): number {
+	if (baselineScope === 0) {
+		return currentScope > 0 ? Number.POSITIVE_INFINITY : 0;
+	}
+	return (currentScope - baselineScope) / baselineScope;
+}
+
+/**
+ * Returns true when the status is considered complete.
+ *
+ * @param {string} status Status value from a roadmap item.
+ * @returns {boolean} True when the status means complete.
+ */
+function isCompletedStatus(status: string): boolean {
+	return COMPLETE_STATUSES.has(status.toLowerCase());
+}
+
+/**
+ * Analyzes baseline vs current snapshots and produces entropy findings.
+ *
+ * @param {RoadmapSnapshot} baseline Baseline snapshot.
+ * @param {RoadmapSnapshot} current Current snapshot.
+ * @param {DetectorThresholds} thresholds Detector thresholds.
+ * @param {string} todayDate Reference date for overdue checks.
+ * @returns {DetectorResult} Detector output payload.
+ */
+export function analyzeSnapshots(
+	baseline: RoadmapSnapshot,
+	current: RoadmapSnapshot,
+	thresholds: DetectorThresholds,
+	todayDate: string,
+): DetectorResult {
+	const todayEpochDay = toEpochDay(todayDate, "today");
+	const baselineById = new Map(baseline.items.map((item) => [item.id, item]));
+	const creepFindings: ScopeCreepFinding[] = [];
+	const driftFindings: DriftFinding[] = [];
+	let severityAccumulator = 0;
+
+	for (const currentItem of current.items) {
+		const baselineItem = baselineById.get(currentItem.id);
+		if (baselineItem == null) {
+			creepFindings.push({
+				type: "new_item",
+				id: currentItem.id,
+				baselineScope: 0,
+				currentScope: currentItem.scopeSize,
+				scopeDelta: currentItem.scopeSize,
+				scopeGrowthRatio: Number.POSITIVE_INFINITY,
+			});
+			severityAccumulator += currentItem.scopeSize;
+		} else {
+			const scopeDelta = currentItem.scopeSize - baselineItem.scopeSize;
+			const growthRatio = computeScopeGrowthRatio(
+				baselineItem.scopeSize,
+				currentItem.scopeSize,
+			);
+			if (scopeDelta > 0 && growthRatio > thresholds.scopeThreshold) {
+				creepFindings.push({
+					type: "scope_increase",
+					id: currentItem.id,
+					baselineScope: baselineItem.scopeSize,
+					currentScope: currentItem.scopeSize,
+					scopeDelta,
+					scopeGrowthRatio: Number(growthRatio.toFixed(4)),
+				});
+				severityAccumulator += growthRatio;
+			}
+
+			const slipDays = currentItem.targetEpochDay - baselineItem.targetEpochDay;
+			if (slipDays > thresholds.driftDaysThreshold) {
+				driftFindings.push({
+					type: "target_slip",
+					id: currentItem.id,
+					status: currentItem.status,
+					baselineTargetDate: baselineItem.targetDate,
+					currentTargetDate: currentItem.targetDate,
+					slipDays,
+					overdueDays: 0,
+				});
+				severityAccumulator += slipDays / 7;
+			}
+		}
+
+		const overdueDays = todayEpochDay - currentItem.targetEpochDay;
+		if (overdueDays > 0 && !isCompletedStatus(currentItem.status)) {
+			driftFindings.push({
+				type: "overdue_incomplete",
+				id: currentItem.id,
+				status: currentItem.status,
+				baselineTargetDate: baselineItem?.targetDate ?? currentItem.targetDate,
+				currentTargetDate: currentItem.targetDate,
+				slipDays: 0,
+				overdueDays,
+			});
+			severityAccumulator += overdueDays / 7;
+		}
+	}
+
+	const normalizedEntropy = Number(
+		(severityAccumulator / Math.max(current.items.length, 1)).toFixed(4),
+	);
+	const creepExceeded = creepFindings.length > thresholds.maxCreep;
+	const driftExceeded = driftFindings.length > thresholds.maxDrift;
+	const entropyExceeded = normalizedEntropy > thresholds.maxEntropy;
+
+	return {
+		status: creepExceeded || driftExceeded || entropyExceeded
+			? ALERT_STATUS
+			: OK_STATUS,
+		meta: {
+			today: fromEpochDay(todayEpochDay),
+		},
+		thresholds,
+		summary: {
+			baselineItemCount: baseline.items.length,
+			currentItemCount: current.items.length,
+			creepCount: creepFindings.length,
+			driftCount: driftFindings.length,
+			entropyScore: normalizedEntropy,
+		},
+		findings: {
+			scopeCreep: creepFindings,
+			scheduleDrift: driftFindings,
+		},
+		gates: {
+			creepExceeded,
+			driftExceeded,
+			entropyExceeded,
+		},
+	};
+}
+
+/**
+ * Parses and validates a snapshot JSON file.
+ *
+ * @param {string} filePath JSON file path.
+ * @param {string} snapshotLabel Label used in validation errors.
+ * @param {(path: string) => Promise<string>} readTextFile Dependency-injected file reader.
+ * @returns {Promise<RoadmapSnapshot>} Parsed snapshot.
+ */
+export async function loadSnapshot(
+	filePath: string,
+	snapshotLabel: string,
+	readTextFile: (path: string) => Promise<string>,
+): Promise<RoadmapSnapshot> {
+	let rawFile = "";
+	try {
+		rawFile = await readTextFile(filePath);
+	} catch (error) {
+		const message = String(error);
+		throw new Error(`Cannot read ${snapshotLabel} file at ${filePath}: ${message}`);
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(rawFile);
+	} catch (error) {
+		const message = String(error);
+		throw new Error(`${snapshotLabel} is not valid JSON: ${message}`);
+	}
+	return validateSnapshot(parsed, snapshotLabel);
+}
+
+/**
+ * Writes a structured JSON payload to stdout.
+ *
+ * @param {(text: string) => void} writeStdout Output function.
+ * @param {unknown} payload Payload to serialize.
+ */
+function writeJson(writeStdout: (text: string) => void, payload: unknown): void {
+	writeStdout(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+/**
+ * Writes a structured error payload to stderr.
+ *
+ * @param {(text: string) => void} writeStderr Error output function.
+ * @param {string} message Human-readable error message.
+ */
+function writeError(writeStderr: (text: string) => void, message: string): void {
+	writeStderr(
+		`${JSON.stringify({ status: ERROR_PREFIX, message }, null, 2)}\n`,
+	);
+}
+
+/**
+ * Runs the detector with dependency-injected IO.
+ *
+ * @param {CliIo} io IO dependencies.
+ * @returns {Promise<number>} Process exit code.
+ */
+export async function runCli(io: CliIo): Promise<number> {
+	let config: CliConfig;
+	try {
+		config = parseArgs(io.args, io.now());
+	} catch (error) {
+		const message = String(error);
+		if (message === getUsage()) {
+			io.writeStdout(`${message}\n`);
+			return 0;
+		}
+		writeError(io.writeStderr, message);
+		return 2;
+	}
+
+	try {
+		const [baselineSnapshot, currentSnapshot] = await Promise.all([
+			loadSnapshot(config.baselinePath, "baseline", io.readTextFile),
+			loadSnapshot(config.currentPath, "current", io.readTextFile),
+		]);
+		const result = analyzeSnapshots(
+			baselineSnapshot,
+			currentSnapshot,
+			config.thresholds,
+			config.today,
+		);
+		writeJson(io.writeStdout, result);
+		return result.status === ALERT_STATUS ? 1 : 0;
+	} catch (error) {
+		const message = String(error);
+		writeError(io.writeStderr, message);
+		return 2;
+	}
+}
+
+if (import.meta.main) {
+	const exitCode = await runCli({
+		args: Deno.args,
+		readTextFile: Deno.readTextFile,
+		writeStdout: (text) => Deno.stdout.writeSync(new TextEncoder().encode(text)),
+		writeStderr: (text) => Deno.stderr.writeSync(new TextEncoder().encode(text)),
+		now: () => new Date(),
+	});
+	Deno.exit(exitCode);
+}

--- a/deno.json
+++ b/deno.json
@@ -41,6 +41,7 @@
 		"build-edge": "deno task dev-edge && bash bin/zip-extension.bash edge",
 		"build-safari": "deno task dev-safari && bash bin/zip-extension.bash safari && bash bin/convert-to-safari-app-extension.bash",
 
+		"roadmap-entropy": "deno run --allow-read bin/roadmap-entropy-detector.ts",
 		"release": "deno --allow-read --allow-run --allow-env bin/build-releases.ts"
 	},
 	"imports": {

--- a/docs/roadmap-entropy-detector.md
+++ b/docs/roadmap-entropy-detector.md
@@ -1,0 +1,124 @@
+# Roadmap Entropy Detector
+
+`Roadmap Entropy Detector` compares two roadmap snapshots and flags:
+
+- scope creep (new work or excessive scope growth)
+- schedule drift (target-date slips and overdue incomplete items)
+
+It emits machine-readable JSON and uses exit codes for CI gates.
+
+## Run
+
+```bash
+deno task roadmap-entropy --baseline baseline.json --current current.json
+```
+
+## Input Schema
+
+Both files are JSON objects with an `items` array.
+
+```json
+{
+  "items": [
+    {
+      "id": "epic-auth",
+      "status": "in_progress",
+      "targetDate": "2026-04-15",
+      "scopePoints": 13
+    },
+    {
+      "id": "epic-billing",
+      "status": "planned",
+      "targetDate": "2026-04-20",
+      "tasks": ["task-1", "task-2", "task-3"]
+    }
+  ]
+}
+```
+
+Required fields per item:
+
+- `id`: non-empty string, unique inside each snapshot
+- `status`: non-empty string
+- `targetDate`: `YYYY-MM-DD`
+- scope value from either:
+  - `scopePoints` (non-negative number), or
+  - `tasks` array length
+
+## Options
+
+- `--scope-threshold <number>`: growth-ratio threshold for creep (`default: 0.1`)
+- `--drift-days-threshold <n>`: allowed target-date slip days (`default: 0`)
+- `--max-creep <n>`: max allowed creep findings (`default: 0`)
+- `--max-drift <n>`: max allowed drift findings (`default: 0`)
+- `--max-entropy <number>`: max allowed entropy score (`default: 0`)
+- `--today <YYYY-MM-DD>`: overrides reference date for overdue checks
+
+## Exit Codes
+
+- `0`: healthy roadmap (`status: "ok"`)
+- `1`: thresholds exceeded (`status: "alert"`)
+- `2`: invalid arguments or invalid input JSON/schema
+
+## Output Example
+
+```json
+{
+  "status": "alert",
+  "meta": {
+    "today": "2026-03-31"
+  },
+  "thresholds": {
+    "scopeThreshold": 0.1,
+    "driftDaysThreshold": 0,
+    "maxCreep": 0,
+    "maxDrift": 0,
+    "maxEntropy": 0
+  },
+  "summary": {
+    "baselineItemCount": 2,
+    "currentItemCount": 3,
+    "creepCount": 2,
+    "driftCount": 1,
+    "entropyScore": 1.5476
+  },
+  "findings": {
+    "scopeCreep": [
+      {
+        "type": "scope_increase",
+        "id": "epic-auth",
+        "baselineScope": 8,
+        "currentScope": 13,
+        "scopeDelta": 5,
+        "scopeGrowthRatio": 0.625
+      },
+      {
+        "type": "new_item",
+        "id": "epic-reporting",
+        "baselineScope": 0,
+        "currentScope": 5,
+        "scopeDelta": 5,
+        "scopeGrowthRatio": null
+      }
+    ],
+    "scheduleDrift": [
+      {
+        "type": "target_slip",
+        "id": "epic-auth",
+        "status": "in_progress",
+        "baselineTargetDate": "2026-04-10",
+        "currentTargetDate": "2026-04-15",
+        "slipDays": 5,
+        "overdueDays": 0
+      }
+    ]
+  },
+  "gates": {
+    "creepExceeded": true,
+    "driftExceeded": true,
+    "entropyExceeded": true
+  }
+}
+```
+
+Note: when a value is `Infinity` in memory (for example growth ratio of a new item), JSON serialization outputs `null`.

--- a/tests/bin/roadmap-entropy-detector.test.ts
+++ b/tests/bin/roadmap-entropy-detector.test.ts
@@ -1,0 +1,902 @@
+import { assertEquals, assertMatch } from "@std/testing/asserts";
+import {
+	analyzeSnapshots,
+	computeScopeGrowthRatio,
+	getUsage,
+	parseArgs,
+	runCli,
+	toEpochDay,
+	validateSnapshot,
+} from "../../bin/roadmap-entropy-detector.ts";
+
+type CliRunResult = {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+};
+
+type ItemInput = {
+	id: string;
+	status: string;
+	targetDate: string;
+	scopePoints?: number;
+	tasks?: string[];
+};
+
+type SnapshotInput = {
+	items: ItemInput[];
+};
+
+const DEFAULT_TODAY = new Date("2026-03-31T00:00:00.000Z");
+
+/**
+ * Creates a JSON string from a snapshot input object.
+ *
+ * @param {SnapshotInput} snapshot Snapshot object to serialize.
+ * @returns {string} Serialized snapshot JSON.
+ */
+function serializeSnapshot(snapshot: SnapshotInput): string {
+	return JSON.stringify(snapshot);
+}
+
+/**
+ * Executes the CLI with injected files and captures outputs.
+ *
+ * @param {{
+ *   args: string[];
+ *   files: Record<string, string>;
+ *   nowDate?: Date;
+ * }} input CLI fixture input.
+ * @returns {Promise<CliRunResult>} Exit code and output streams.
+ */
+async function runCliWithFiles({
+	args,
+	files,
+	nowDate = DEFAULT_TODAY,
+}: {
+	args: string[];
+	files: Record<string, string>;
+	nowDate?: Date;
+}): Promise<CliRunResult> {
+	let stdout = "";
+	let stderr = "";
+	const exitCode = await runCli({
+		args,
+		readTextFile: (path: string) => {
+			if (Object.hasOwn(files, path)) {
+				return Promise.resolve(files[path]);
+			}
+			throw new Error("file not found");
+		},
+		writeStdout: (text: string) => {
+			stdout += text;
+		},
+		writeStderr: (text: string) => {
+			stderr += text;
+		},
+		now: () => nowDate,
+	});
+	return {
+		exitCode,
+		stdout,
+		stderr,
+	};
+}
+
+/**
+ * Parses newline-terminated JSON output into an object.
+ *
+ * @param {string} output JSON output payload.
+ * @returns {Record<string, unknown>} Parsed object.
+ */
+function parseOutput(output: string): Record<string, unknown> {
+	return JSON.parse(output) as Record<string, unknown>;
+}
+
+Deno.test("parseArgs returns defaults and required paths", () => {
+	const config = parseArgs(
+		["--baseline", "base.json", "--current", "curr.json"],
+		new Date("2026-03-10T00:00:00.000Z"),
+	);
+	assertEquals(config.baselinePath, "base.json");
+	assertEquals(config.currentPath, "curr.json");
+	assertEquals(config.today, "2026-03-10");
+	assertEquals(config.thresholds, {
+		scopeThreshold: 0.1,
+		driftDaysThreshold: 0,
+		maxCreep: 0,
+		maxDrift: 0,
+		maxEntropy: 0,
+	});
+
+	const configWithOverrides = parseArgs(
+		[
+			"--baseline",
+			"base.json",
+			"--current",
+			"curr.json",
+			"--scope-threshold",
+			"0.25",
+		],
+		DEFAULT_TODAY,
+	);
+	assertEquals(configWithOverrides.thresholds.scopeThreshold, 0.25);
+});
+
+Deno.test("parseArgs throws on unknown options and bad numeric values", () => {
+	assertEquals(getUsage().includes("Roadmap Entropy Detector"), true);
+	try {
+		parseArgs(["--baseline", "a", "--current", "b", "--x"], DEFAULT_TODAY);
+		throw new Error("Expected parseArgs to throw on unknown option.");
+	} catch (error) {
+		if (!(error instanceof Error)) {
+			throw error;
+		}
+		assertEquals(error.message, "Unknown option: --x");
+	}
+	try {
+		parseArgs(
+			[
+				"--baseline",
+				"a",
+				"--current",
+				"b",
+				"--drift-days-threshold",
+				"0.5",
+			],
+			DEFAULT_TODAY,
+		);
+		throw new Error("Expected parseArgs to reject non-integer drift threshold.");
+	} catch (error) {
+		if (!(error instanceof Error)) {
+			throw error;
+		}
+		assertEquals(
+			error.message,
+			"--drift-days-threshold must be a non-negative integer.",
+		);
+	}
+	try {
+		parseArgs(
+			[
+				"--baseline",
+				"a",
+				"--current",
+				"b",
+				"--scope-threshold",
+				"-1",
+			],
+			DEFAULT_TODAY,
+		);
+		throw new Error("Expected parseArgs to reject negative scope threshold.");
+	} catch (error) {
+		if (!(error instanceof Error)) {
+			throw error;
+		}
+		assertEquals(
+			error.message,
+			"--scope-threshold must be a non-negative number.",
+		);
+	}
+	try {
+		parseArgs(["--baseline"], DEFAULT_TODAY);
+		throw new Error("Expected parseArgs to reject missing option value.");
+	} catch (error) {
+		if (!(error instanceof Error)) {
+			throw error;
+		}
+		assertEquals(error.message, "--baseline requires a value.");
+	}
+	try {
+		parseArgs([], DEFAULT_TODAY);
+		throw new Error("Expected parseArgs to reject missing required arguments.");
+	} catch (error) {
+		if (!(error instanceof Error)) {
+			throw error;
+		}
+		assertEquals(error.message, "--baseline is required.");
+	}
+	try {
+		parseArgs(["--baseline", "a"], DEFAULT_TODAY);
+		throw new Error("Expected parseArgs to require --current.");
+	} catch (error) {
+		if (!(error instanceof Error)) {
+			throw error;
+		}
+		assertEquals(error.message, "--current is required.");
+	}
+});
+
+Deno.test("toEpochDay validates date format and calendar dates", () => {
+	assertEquals(toEpochDay("2026-03-31", "today") > 0, true);
+	try {
+		toEpochDay("2026/03/31", "today");
+		throw new Error("Expected invalid format to throw.");
+	} catch (error) {
+		if (!(error instanceof Error)) {
+			throw error;
+		}
+		assertEquals(error.message, "today must be in YYYY-MM-DD format.");
+	}
+	try {
+		toEpochDay("2026-02-30", "today");
+		throw new Error("Expected invalid date to throw.");
+	} catch (error) {
+		if (!(error instanceof Error)) {
+			throw error;
+		}
+		assertEquals(error.message, "today is not a valid calendar date.");
+	}
+});
+
+Deno.test("validateSnapshot accepts tasks-based scope and rejects duplicates", () => {
+	const validSnapshot = validateSnapshot(
+		{
+			items: [
+				{
+					id: "item-1",
+					status: "planned",
+					targetDate: "2026-04-10",
+					tasks: ["a", "b"],
+				},
+			],
+		},
+		"baseline",
+	);
+	assertEquals(validSnapshot.items[0].scopeSize, 2);
+
+	try {
+		validateSnapshot([], "baseline");
+		throw new Error("Expected non-object snapshot to throw.");
+	} catch (error) {
+		if (!(error instanceof Error)) {
+			throw error;
+		}
+		assertEquals(error.message, "baseline must be a JSON object.");
+	}
+
+	try {
+		validateSnapshot(
+			{
+				items: [5],
+			},
+			"baseline",
+		);
+		throw new Error("Expected non-object item to throw.");
+	} catch (error) {
+		if (!(error instanceof Error)) {
+			throw error;
+		}
+		assertEquals(error.message, "baseline.items[0] must be an object.");
+	}
+
+	try {
+		validateSnapshot(
+			{
+				items: [
+					{
+						id: "bad-status",
+						status: "",
+						targetDate: "2026-04-10",
+						scopePoints: 1,
+					},
+				],
+			},
+			"baseline",
+		);
+		throw new Error("Expected empty status to throw.");
+	} catch (error) {
+		if (!(error instanceof Error)) {
+			throw error;
+		}
+		assertEquals(
+			error.message,
+			"baseline.items[0].status must be a non-empty string.",
+		);
+	}
+
+	try {
+		validateSnapshot(
+			{
+				items: [
+					{
+						id: "bad-date",
+						status: "planned",
+						targetDate: 123,
+						scopePoints: 1,
+					},
+				],
+			},
+			"baseline",
+		);
+		throw new Error("Expected non-string date to throw.");
+	} catch (error) {
+		if (!(error instanceof Error)) {
+			throw error;
+		}
+		assertEquals(
+			error.message,
+			"baseline.items[0].targetDate must be a string in YYYY-MM-DD format.",
+		);
+	}
+
+	try {
+		validateSnapshot(
+			{
+				items: [
+					{
+						id: "bad-scope",
+						status: "planned",
+						targetDate: "2026-04-10",
+						scopePoints: -1,
+					},
+				],
+			},
+			"baseline",
+		);
+		throw new Error("Expected invalid scopePoints to throw.");
+	} catch (error) {
+		if (!(error instanceof Error)) {
+			throw error;
+		}
+		assertEquals(
+			error.message,
+			"baseline.items[0].scopePoints must be a non-negative number when provided.",
+		);
+	}
+
+	try {
+		validateSnapshot(
+			{
+				items: [
+					{
+						id: "bad-scope-source",
+						status: "planned",
+						targetDate: "2026-04-10",
+					},
+				],
+			},
+			"baseline",
+		);
+		throw new Error("Expected missing scope source to throw.");
+	} catch (error) {
+		if (!(error instanceof Error)) {
+			throw error;
+		}
+		assertEquals(
+			error.message,
+			"baseline.items[0] must include scopePoints or tasks.",
+		);
+	}
+
+	try {
+		validateSnapshot(
+			{
+				items: [
+					{
+						id: "dup",
+						status: "planned",
+						targetDate: "2026-04-10",
+						scopePoints: 1,
+					},
+					{
+						id: "dup",
+						status: "planned",
+						targetDate: "2026-04-12",
+						scopePoints: 2,
+					},
+				],
+			},
+			"current",
+		);
+		throw new Error("Expected duplicate IDs to throw.");
+	} catch (error) {
+		if (!(error instanceof Error)) {
+			throw error;
+		}
+		assertEquals(error.message, "current.items contains a duplicate id: dup");
+	}
+});
+
+Deno.test("computeScopeGrowthRatio covers zero-baseline cases", () => {
+	assertEquals(computeScopeGrowthRatio(10, 12), 0.2);
+	assertEquals(computeScopeGrowthRatio(0, 0), 0);
+	assertEquals(computeScopeGrowthRatio(0, 3), Number.POSITIVE_INFINITY);
+});
+
+Deno.test("analyzeSnapshots detects creep, slip drift, overdue drift, and entropy gates", () => {
+	const baseline = validateSnapshot(
+		{
+			items: [
+				{
+					id: "a",
+					status: "planned",
+					targetDate: "2026-04-01",
+					scopePoints: 5,
+				},
+				{
+					id: "b",
+					status: "planned",
+					targetDate: "2026-03-20",
+					scopePoints: 3,
+				},
+			],
+		},
+		"baseline",
+	);
+	const current = validateSnapshot(
+		{
+			items: [
+				{
+					id: "a",
+					status: "in_progress",
+					targetDate: "2026-04-05",
+					scopePoints: 8,
+				},
+				{
+					id: "b",
+					status: "in_progress",
+					targetDate: "2026-03-20",
+					scopePoints: 3,
+				},
+				{
+					id: "c",
+					status: "planned",
+					targetDate: "2026-04-10",
+					scopePoints: 2,
+				},
+			],
+		},
+		"current",
+	);
+	const result = analyzeSnapshots(
+		baseline,
+		current,
+		{
+			scopeThreshold: 0.1,
+			driftDaysThreshold: 0,
+			maxCreep: 1,
+			maxDrift: 1,
+			maxEntropy: 1,
+		},
+		"2026-03-31",
+	);
+
+	assertEquals(result.status, "alert");
+	assertEquals(result.summary.creepCount, 2);
+	assertEquals(result.summary.driftCount, 2);
+	assertEquals(result.findings.scopeCreep[0].type, "scope_increase");
+	assertEquals(result.findings.scopeCreep[1].type, "new_item");
+	assertEquals(result.findings.scheduleDrift[0].type, "target_slip");
+	assertEquals(result.findings.scheduleDrift[1].type, "overdue_incomplete");
+	assertEquals(result.gates.creepExceeded, true);
+	assertEquals(result.gates.driftExceeded, true);
+	assertEquals(result.gates.entropyExceeded, true);
+});
+
+Deno.test("analyzeSnapshots marks complete overdue items as non-drift and clean when unchanged", () => {
+	const baseline = validateSnapshot(
+		{
+			items: [
+				{
+					id: "done-item",
+					status: "planned",
+					targetDate: "2026-03-20",
+					scopePoints: 2,
+				},
+			],
+		},
+		"baseline",
+	);
+	const current = validateSnapshot(
+		{
+			items: [
+				{
+					id: "done-item",
+					status: "done",
+					targetDate: "2026-03-20",
+					scopePoints: 2,
+				},
+			],
+		},
+		"current",
+	);
+	const result = analyzeSnapshots(
+		baseline,
+		current,
+		{
+			scopeThreshold: 0.2,
+			driftDaysThreshold: 1,
+			maxCreep: 0,
+			maxDrift: 0,
+			maxEntropy: 0,
+		},
+		"2026-03-31",
+	);
+
+	assertEquals(result.status, "ok");
+	assertEquals(result.summary.creepCount, 0);
+	assertEquals(result.summary.driftCount, 0);
+	assertEquals(result.summary.entropyScore, 0);
+	assertEquals(result.gates.entropyExceeded, false);
+});
+
+Deno.test("analyzeSnapshots uses current target date as baseline for overdue new items", () => {
+	const baseline = validateSnapshot(
+		{
+			items: [],
+		},
+		"baseline",
+	);
+	const current = validateSnapshot(
+		{
+			items: [
+				{
+					id: "new-overdue",
+					status: "in_progress",
+					targetDate: "2026-03-10",
+					scopePoints: 2,
+				},
+			],
+		},
+		"current",
+	);
+	const result = analyzeSnapshots(
+		baseline,
+		current,
+		{
+			scopeThreshold: 0.1,
+			driftDaysThreshold: 0,
+			maxCreep: 10,
+			maxDrift: 10,
+			maxEntropy: 100,
+		},
+		"2026-03-31",
+	);
+	assertEquals(result.summary.driftCount, 1);
+	assertEquals(result.findings.scheduleDrift[0].baselineTargetDate, "2026-03-10");
+});
+
+Deno.test("runCli returns healthy status and zero exit code for unchanged roadmap", async () => {
+	const baseSnapshot = serializeSnapshot({
+		items: [
+			{
+				id: "alpha",
+				status: "planned",
+				targetDate: "2026-04-20",
+				scopePoints: 3,
+			},
+		],
+	});
+	const result = await runCliWithFiles({
+		args: ["--baseline", "base.json", "--current", "current.json"],
+		files: {
+			"base.json": baseSnapshot,
+			"current.json": baseSnapshot,
+		},
+	});
+	assertEquals(result.exitCode, 0);
+	assertEquals(result.stderr, "");
+	const payload = parseOutput(result.stdout);
+	assertEquals(payload.status, "ok");
+	assertEquals(
+		(payload.summary as Record<string, unknown>).entropyScore,
+		0,
+	);
+});
+
+Deno.test("runCli detects creep-only scenarios", async () => {
+	const result = await runCliWithFiles({
+		args: [
+			"--baseline",
+			"baseline.json",
+			"--current",
+			"current.json",
+			"--today",
+			"2026-03-01",
+		],
+		files: {
+			"baseline.json": serializeSnapshot({
+				items: [
+					{
+						id: "creep",
+						status: "planned",
+						targetDate: "2026-04-20",
+						scopePoints: 5,
+					},
+				],
+			}),
+			"current.json": serializeSnapshot({
+				items: [
+					{
+						id: "creep",
+						status: "planned",
+						targetDate: "2026-04-20",
+						scopePoints: 7,
+					},
+				],
+			}),
+		},
+	});
+
+	assertEquals(result.exitCode, 1);
+	const payload = parseOutput(result.stdout);
+	assertEquals(payload.status, "alert");
+	assertEquals((payload.summary as Record<string, unknown>).creepCount, 1);
+	assertEquals((payload.summary as Record<string, unknown>).driftCount, 0);
+});
+
+Deno.test("runCli detects drift-only scenarios", async () => {
+	const result = await runCliWithFiles({
+		args: [
+			"--baseline",
+			"baseline.json",
+			"--current",
+			"current.json",
+			"--today",
+			"2026-03-31",
+		],
+		files: {
+			"baseline.json": serializeSnapshot({
+				items: [
+					{
+						id: "drift",
+						status: "planned",
+						targetDate: "2026-03-15",
+						scopePoints: 2,
+					},
+				],
+			}),
+			"current.json": serializeSnapshot({
+				items: [
+					{
+						id: "drift",
+						status: "in_progress",
+						targetDate: "2026-03-30",
+						scopePoints: 2,
+					},
+				],
+			}),
+		},
+	});
+
+	assertEquals(result.exitCode, 1);
+	const payload = parseOutput(result.stdout);
+	assertEquals((payload.summary as Record<string, unknown>).creepCount, 0);
+	assertEquals((payload.summary as Record<string, unknown>).driftCount, 2);
+});
+
+Deno.test("runCli supports threshold overrides to allow findings", async () => {
+	const result = await runCliWithFiles({
+		args: [
+			"--baseline",
+			"baseline.json",
+			"--current",
+			"current.json",
+			"--today",
+			"2026-03-31",
+			"--max-creep",
+			"5",
+			"--max-drift",
+			"5",
+			"--max-entropy",
+			"10",
+		],
+		files: {
+			"baseline.json": serializeSnapshot({
+				items: [
+					{
+						id: "x",
+						status: "planned",
+						targetDate: "2026-03-15",
+						scopePoints: 1,
+					},
+				],
+			}),
+			"current.json": serializeSnapshot({
+				items: [
+					{
+						id: "x",
+						status: "in_progress",
+						targetDate: "2026-03-20",
+						scopePoints: 3,
+					},
+				],
+			}),
+		},
+	});
+
+	assertEquals(result.exitCode, 0);
+	const payload = parseOutput(result.stdout);
+	assertEquals(payload.status, "ok");
+});
+
+Deno.test("runCli reports malformed schema and missing IDs", async () => {
+	const malformed = await runCliWithFiles({
+		args: ["--baseline", "bad.json", "--current", "ok.json"],
+		files: {
+			"bad.json": JSON.stringify({ noItems: [] }),
+			"ok.json": serializeSnapshot({
+				items: [
+					{
+						id: "ok",
+						status: "planned",
+						targetDate: "2026-05-01",
+						scopePoints: 1,
+					},
+				],
+			}),
+		},
+	});
+	assertEquals(malformed.exitCode, 2);
+	assertEquals(malformed.stdout, "");
+	assertMatch(malformed.stderr, /baseline\.items must be an array/);
+
+	const missingId = await runCliWithFiles({
+		args: ["--baseline", "bad-id.json", "--current", "ok.json"],
+		files: {
+			"bad-id.json": JSON.stringify({
+				items: [
+					{
+						status: "planned",
+						targetDate: "2026-05-01",
+						scopePoints: 1,
+					},
+				],
+			}),
+			"ok.json": serializeSnapshot({
+				items: [
+					{
+						id: "ok",
+						status: "planned",
+						targetDate: "2026-05-01",
+						scopePoints: 1,
+					},
+				],
+			}),
+		},
+	});
+	assertEquals(missingId.exitCode, 2);
+	assertMatch(missingId.stderr, /baseline\.items\[0\]\.id must be a non-empty string/);
+});
+
+Deno.test("runCli handles help output, invalid json, and missing files", async () => {
+	const helpResult = await runCliWithFiles({
+		args: ["--help"],
+		files: {},
+	});
+	assertEquals(helpResult.exitCode, 0);
+	assertEquals(helpResult.stderr, "");
+	assertMatch(helpResult.stdout, /Roadmap Entropy Detector/);
+
+	const invalidJson = await runCliWithFiles({
+		args: ["--baseline", "base.json", "--current", "current.json"],
+		files: {
+			"base.json": "{",
+			"current.json": serializeSnapshot({
+				items: [
+					{
+						id: "ok",
+						status: "planned",
+						targetDate: "2026-05-01",
+						scopePoints: 1,
+					},
+				],
+			}),
+		},
+	});
+	assertEquals(invalidJson.exitCode, 2);
+	assertMatch(invalidJson.stderr, /baseline is not valid JSON/);
+
+	const missingFile = await runCliWithFiles({
+		args: ["--baseline", "base.json", "--current", "missing.json"],
+		files: {
+			"base.json": serializeSnapshot({
+				items: [
+					{
+						id: "ok",
+						status: "planned",
+						targetDate: "2026-05-01",
+						scopePoints: 1,
+					},
+				],
+			}),
+		},
+	});
+	assertEquals(missingFile.exitCode, 2);
+	assertMatch(missingFile.stderr, /Cannot read current file/);
+});
+
+Deno.test("runCli returns parse errors through stderr payload", async () => {
+	const parseError = await runCliWithFiles({
+		args: ["--baseline", "base.json", "--current", "current.json", "--unknown"],
+		files: {},
+	});
+	assertEquals(parseError.exitCode, 2);
+	assertEquals(parseError.stdout, "");
+	assertMatch(parseError.stderr, /Unknown option: --unknown/);
+});
+
+Deno.test("CLI subprocess executes import.meta.main path", async () => {
+	const tempDir = await Deno.makeTempDir();
+	try {
+		const baselinePath = `${tempDir}/baseline.json`;
+		const currentPath = `${tempDir}/current.json`;
+		await Deno.writeTextFile(
+			baselinePath,
+			serializeSnapshot({
+				items: [
+					{
+						id: "subprocess",
+						status: "planned",
+						targetDate: "2026-05-01",
+						scopePoints: 1,
+					},
+				],
+			}),
+		);
+		await Deno.writeTextFile(
+			currentPath,
+			serializeSnapshot({
+				items: [
+					{
+						id: "subprocess",
+						status: "planned",
+						targetDate: "2026-05-01",
+						scopePoints: 1,
+					},
+				],
+			}),
+		);
+		const cliFile = new URL(
+			"../../bin/roadmap-entropy-detector.ts",
+			import.meta.url,
+		).pathname;
+		const output = await new Deno.Command(Deno.execPath(), {
+			args: [
+				"run",
+				"--allow-read",
+				cliFile,
+				"--baseline",
+				baselinePath,
+				"--current",
+				currentPath,
+			],
+			stdout: "piped",
+			stderr: "piped",
+		}).output();
+
+		const stdoutText = new TextDecoder().decode(output.stdout);
+		const stderrText = new TextDecoder().decode(output.stderr);
+		assertEquals(output.code, 0);
+		assertEquals(stderrText, "");
+		const payload = parseOutput(stdoutText);
+		assertEquals(payload.status, "ok");
+	} finally {
+		await Deno.remove(tempDir, { recursive: true });
+	}
+});
+
+Deno.test("CLI subprocess writes stderr for invalid arguments", async () => {
+	const cliFile = new URL(
+		"../../bin/roadmap-entropy-detector.ts",
+		import.meta.url,
+	).pathname;
+	const output = await new Deno.Command(Deno.execPath(), {
+		args: [
+			"run",
+			"--allow-read",
+			cliFile,
+			"--baseline",
+			"only-baseline.json",
+		],
+		stdout: "piped",
+		stderr: "piped",
+	}).output();
+
+	const stdoutText = new TextDecoder().decode(output.stdout);
+	const stderrText = new TextDecoder().decode(output.stderr);
+	assertEquals(output.code, 2);
+	assertEquals(stdoutText, "");
+	assertMatch(stderrText, /--current is required/);
+});


### PR DESCRIPTION
## Summary
- add a new Deno CLI at bin/roadmap-entropy-detector.ts to compare baseline and current roadmap snapshots
- detect scope creep and schedule drift, compute entropy score, emit machine-readable JSON, and enforce threshold-based exit codes
- add deno task roadmap-entropy and document schema/usage in docs/roadmap-entropy-detector.md
- add comprehensive tests in tests/bin/roadmap-entropy-detector.test.ts with full 100/100/100 coverage for the detector

## Validation
- deno lint
- deno test --allow-read --allow-write --allow-run --coverage=coverage/roadmap tests/bin/roadmap-entropy-detector.test.ts