### PR TITLE
feat: add roadmap entropy detector

### DIFF
--- a/bin/roadmap-entropy-detector.ts
+++ b/bin/roadmap-entropy-detector.ts
@@ -179,7 +179,11 @@ function parseNonNegativeNumber(rawValue: string, optionName: string): number {
 /**
  * Reads the next argument as an option value.
  */
-function getOptionValue(args: string[], index: number, optionName: string): string {
+function getOptionValue(
+	args: string[],
+	index: number,
+	optionName: string,
+): string {
 	const value = args[index + 1];
 	if (!value || value.startsWith("--")) {
 		throwOptionError(`${optionName} requires a value.`);
@@ -226,22 +230,34 @@ function parseCliArgs(args: string[]): CliOptions | { help: true } {
 				break;
 			}
 			case "--scope-increase-threshold-pct": {
-				scopeIncreaseThresholdPct = parseNonNegativeNumber(getOptionValue(args, index, arg), arg);
+				scopeIncreaseThresholdPct = parseNonNegativeNumber(
+					getOptionValue(args, index, arg),
+					arg,
+				);
 				index += 1;
 				break;
 			}
 			case "--max-creep-findings": {
-				maxCreepFindings = parseNonNegativeNumber(getOptionValue(args, index, arg), arg);
+				maxCreepFindings = parseNonNegativeNumber(
+					getOptionValue(args, index, arg),
+					arg,
+				);
 				index += 1;
 				break;
 			}
 			case "--max-drift-findings": {
-				maxDriftFindings = parseNonNegativeNumber(getOptionValue(args, index, arg), arg);
+				maxDriftFindings = parseNonNegativeNumber(
+					getOptionValue(args, index, arg),
+					arg,
+				);
 				index += 1;
 				break;
 			}
 			case "--max-entropy-score": {
-				maxEntropyScore = parseNonNegativeNumber(getOptionValue(args, index, arg), arg);
+				maxEntropyScore = parseNonNegativeNumber(
+					getOptionValue(args, index, arg),
+					arg,
+				);
 				index += 1;
 				break;
 			}
@@ -304,7 +320,10 @@ function toEpochDays(value: string, fieldName: string): number {
 /**
  * Casts a JSON value to a string-keyed object.
  */
-function asObject(value: JsonValue, fieldName: string): { [key: string]: JsonValue } {
+function asObject(
+	value: JsonValue,
+	fieldName: string,
+): { [key: string]: JsonValue } {
 	if (typeof value !== "object" || value === null || Array.isArray(value)) {
 		throw new Error(`${fieldName} must be an object.`);
 	}
@@ -315,7 +334,10 @@ function asObject(value: JsonValue, fieldName: string): { [key: string]: JsonVal
 /**
  * Reads and parses JSON content from disk.
  */
-async function readJsonFile(path: string, readTextFile: (path: string) => Promise<string>): Promise<JsonValue> {
+async function readJsonFile(
+	path: string,
+	readTextFile: (path: string) => Promise<string>,
+): Promise<JsonValue> {
 	const rawText = await readTextFile(path);
 	try {
 		return JSON.parse(rawText) as JsonValue;
@@ -327,7 +349,10 @@ async function readJsonFile(path: string, readTextFile: (path: string) => Promis
 /**
  * Validates that the provided value is a valid roadmap snapshot.
  */
-function validateSnapshot(value: JsonValue, label: "baseline" | "current"): RoadmapSnapshot {
+function validateSnapshot(
+	value: JsonValue,
+	label: "baseline" | "current",
+): RoadmapSnapshot {
 	const snapshotObject = asObject(value, `${label} snapshot`);
 	const itemsValue = snapshotObject.items;
 
@@ -342,7 +367,9 @@ function validateSnapshot(value: JsonValue, label: "baseline" | "current"): Road
 	const uniqueIds = new Set<string>();
 	for (const item of items) {
 		if (uniqueIds.has(item.id)) {
-			throw new Error(`${label} snapshot has duplicate item id '${item.id}'.`);
+			throw new Error(
+				`${label} snapshot has duplicate item id '${item.id}'.`,
+			);
 		}
 		uniqueIds.add(item.id);
 	}
@@ -353,25 +380,41 @@ function validateSnapshot(value: JsonValue, label: "baseline" | "current"): Road
 /**
  * Validates and normalizes a snapshot item.
  */
-function validateItem(value: JsonValue, label: "baseline" | "current", index: number): RoadmapItem {
-	const itemObject = asObject(value, `${label} snapshot item at index ${index}`);
+function validateItem(
+	value: JsonValue,
+	label: "baseline" | "current",
+	index: number,
+): RoadmapItem {
+	const itemObject = asObject(
+		value,
+		`${label} snapshot item at index ${index}`,
+	);
 
 	const id = itemObject.id;
 	if (typeof id !== "string" || id.trim() === "") {
-		throw new Error(`${label} snapshot item at index ${index} must have a non-empty id.`);
+		throw new Error(
+			`${label} snapshot item at index ${index} must have a non-empty id.`,
+		);
 	}
 
 	const status = itemObject.status;
 	if (typeof status !== "string" || status.trim() === "") {
-		throw new Error(`${label} snapshot item '${id}' must have a non-empty status.`);
+		throw new Error(
+			`${label} snapshot item '${id}' must have a non-empty status.`,
+		);
 	}
 
 	const targetDate = itemObject.targetDate;
 	if (typeof targetDate !== "string") {
-		throw new Error(`${label} snapshot item '${id}' must have a targetDate string.`);
+		throw new Error(
+			`${label} snapshot item '${id}' must have a targetDate string.`,
+		);
 	}
 
-	const targetDateEpochDays = toEpochDays(targetDate, `${label} snapshot item '${id}' targetDate`);
+	const targetDateEpochDays = toEpochDays(
+		targetDate,
+		`${label} snapshot item '${id}' targetDate`,
+	);
 	const scopeSize = getScopeSize(itemObject, label, id);
 
 	return {
@@ -386,11 +429,17 @@ function validateItem(value: JsonValue, label: "baseline" | "current", index: nu
 /**
  * Resolves scope size from scopePoints or tasks.length.
  */
-function getScopeSize(itemObject: { [key: string]: JsonValue }, label: "baseline" | "current", id: string): number {
+function getScopeSize(
+	itemObject: { [key: string]: JsonValue },
+	label: "baseline" | "current",
+	id: string,
+): number {
 	const scopePoints = itemObject.scopePoints;
 	if (typeof scopePoints === "number") {
 		if (!Number.isFinite(scopePoints) || scopePoints < 0) {
-			throw new Error(`${label} snapshot item '${id}' scopePoints must be a non-negative number.`);
+			throw new Error(
+				`${label} snapshot item '${id}' scopePoints must be a non-negative number.`,
+			);
 		}
 		return scopePoints;
 	}
@@ -399,13 +448,17 @@ function getScopeSize(itemObject: { [key: string]: JsonValue }, label: "baseline
 	if (Array.isArray(tasks)) {
 		for (const task of tasks) {
 			if (typeof task !== "string") {
-				throw new Error(`${label} snapshot item '${id}' tasks must contain only strings.`);
+				throw new Error(
+					`${label} snapshot item '${id}' tasks must contain only strings.`,
+				);
 			}
 		}
 		return tasks.length;
 	}
 
-	throw new Error(`${label} snapshot item '${id}' must include scopePoints or tasks.`);
+	throw new Error(
+		`${label} snapshot item '${id}' must include scopePoints or tasks.`,
+	);
 }
 
 /**
@@ -434,7 +487,9 @@ function getIncreasePct(baselineScope: number, currentScope: number): number {
 		return currentScope > 0 ? 100 : 0;
 	}
 
-	return Number((((currentScope - baselineScope) / baselineScope) * 100).toFixed(2));
+	return Number(
+		(((currentScope - baselineScope) / baselineScope) * 100).toFixed(2),
+	);
 }
 
 /**
@@ -486,9 +541,16 @@ function detectRoadmapEntropy(
 				totalScopeIncrease += currentItem.scopeSize;
 			}
 		} else {
-			const increasePoints = currentItem.scopeSize - baselineItem.scopeSize;
-			const increasePct = getIncreasePct(baselineItem.scopeSize, currentItem.scopeSize);
-			if (increasePoints > 0 && increasePct > options.scopeIncreaseThresholdPct) {
+			const increasePoints = currentItem.scopeSize -
+				baselineItem.scopeSize;
+			const increasePct = getIncreasePct(
+				baselineItem.scopeSize,
+				currentItem.scopeSize,
+			);
+			if (
+				increasePoints > 0 &&
+				increasePct > options.scopeIncreaseThresholdPct
+			) {
 				creepFindings.push({
 					type: "scope_creep",
 					id: currentItem.id,
@@ -502,10 +564,15 @@ function detectRoadmapEntropy(
 			}
 		}
 
-		const baselineTargetEpochDays = baselineItem?.targetDateEpochDays ?? currentItem.targetDateEpochDays;
+		const baselineTargetEpochDays = baselineItem?.targetDateEpochDays ??
+			currentItem.targetDateEpochDays;
 		const baselineTargetDate = baselineItem?.targetDate ?? null;
-		const slipDays = getSlipDays(baselineTargetEpochDays, currentItem.targetDateEpochDays);
-		const overdue = isIncompleteStatus(currentItem.status) && todayEpochDays > currentItem.targetDateEpochDays;
+		const slipDays = getSlipDays(
+			baselineTargetEpochDays,
+			currentItem.targetDateEpochDays,
+		);
+		const overdue = isIncompleteStatus(currentItem.status) &&
+			todayEpochDays > currentItem.targetDateEpochDays;
 
 		if (slipDays > 0 || overdue) {
 			driftFindings.push({
@@ -531,7 +598,8 @@ function detectRoadmapEntropy(
 	}
 
 	const entropyScore = Number(
-		(creepFindings.length * 5 + driftFindings.length * 5 + totalSlipDays + totalScopeIncrease).toFixed(2),
+		(creepFindings.length * 5 + driftFindings.length * 5 + totalSlipDays +
+			totalScopeIncrease).toFixed(2),
 	);
 
 	const exceeded: ThresholdEvaluation = {
@@ -540,9 +608,10 @@ function detectRoadmapEntropy(
 		entropy: entropyScore > options.maxEntropyScore,
 	};
 
-	const status: DetectorResult["status"] = exceeded.creep || exceeded.drift || exceeded.entropy
-		? "alert"
-		: "healthy";
+	const status: DetectorResult["status"] =
+		exceeded.creep || exceeded.drift || exceeded.entropy
+			? "alert"
+			: "healthy";
 
 	const metrics: RoadmapMetrics = {
 		baselineItemCount: baseline.items.length,
@@ -581,7 +650,10 @@ function detectRoadmapEntropy(
  * Returns CLI exit code for the detector result.
  */
 function getExitCode(result: DetectorResult): number {
-	return result.exceeded.creep || result.exceeded.drift || result.exceeded.entropy ? 2 : 0;
+	return result.exceeded.creep || result.exceeded.drift ||
+			result.exceeded.entropy
+		? 2
+		: 0;
 }
 
 /**
@@ -600,11 +672,21 @@ export async function runRoadmapEntropyDetectorCli(
 			};
 		}
 
-		const baselineValue = await readJsonFile(parsedArgs.baselinePath, readTextFile);
-		const currentValue = await readJsonFile(parsedArgs.currentPath, readTextFile);
+		const baselineValue = await readJsonFile(
+			parsedArgs.baselinePath,
+			readTextFile,
+		);
+		const currentValue = await readJsonFile(
+			parsedArgs.currentPath,
+			readTextFile,
+		);
 		const baselineSnapshot = validateSnapshot(baselineValue, "baseline");
 		const currentSnapshot = validateSnapshot(currentValue, "current");
-		const result = detectRoadmapEntropy(baselineSnapshot, currentSnapshot, parsedArgs);
+		const result = detectRoadmapEntropy(
+			baselineSnapshot,
+			currentSnapshot,
+			parsedArgs,
+		);
 
 		return {
 			exitCode: getExitCode(result),
@@ -622,12 +704,19 @@ export async function runRoadmapEntropyDetectorCli(
 /**
  * Executes CLI behavior when module runs as an entrypoint.
  */
-export async function maybeRunMain(isMain: boolean, args: string[], dependencies: CliDependencies): Promise<void> {
+export async function maybeRunMain(
+	isMain: boolean,
+	args: string[],
+	dependencies: CliDependencies,
+): Promise<void> {
 	if (!isMain) {
 		return;
 	}
 
-	const runResult = await runRoadmapEntropyDetectorCli(args, dependencies.readTextFile);
+	const runResult = await runRoadmapEntropyDetectorCli(
+		args,
+		dependencies.readTextFile,
+	);
 	if (runResult.output) {
 		dependencies.writeStdout(runResult.output);
 	}

--- a/bin/roadmap-entropy-detector.ts
+++ b/bin/roadmap-entropy-detector.ts
@@ -1,0 +1,647 @@
+/**
+ * Minimal JSON value shape used for parsing and validation.
+ */
+export type JsonValue =
+	| string
+	| number
+	| boolean
+	| null
+	| JsonValue[]
+	| { [key: string]: JsonValue };
+
+/**
+ * Normalized roadmap item used internally.
+ */
+interface RoadmapItem {
+	id: string;
+	status: string;
+	targetDate: string;
+	targetDateEpochDays: number;
+	scopeSize: number;
+}
+
+/**
+ * Normalized roadmap snapshot.
+ */
+interface RoadmapSnapshot {
+	items: RoadmapItem[];
+}
+
+/**
+ * CLI options accepted by the detector.
+ */
+interface CliOptions {
+	baselinePath: string;
+	currentPath: string;
+	today: string;
+	scopeIncreaseThresholdPct: number;
+	maxCreepFindings: number;
+	maxDriftFindings: number;
+	maxEntropyScore: number;
+}
+
+/**
+ * Scope creep finding payload.
+ */
+interface ScopeCreepFinding {
+	type: "scope_creep";
+	id: string;
+	increasePoints: number;
+	increasePct: number;
+	baselineScope: number;
+	currentScope: number;
+	reason: "scope_increase" | "new_item";
+}
+
+/**
+ * Drift finding payload.
+ */
+interface DriftFinding {
+	type: "schedule_drift";
+	id: string;
+	slipDays: number;
+	overdue: boolean;
+	baselineTargetDate: string | null;
+	currentTargetDate: string;
+	status: string;
+}
+
+/**
+ * Aggregated detector metrics.
+ */
+interface RoadmapMetrics {
+	baselineItemCount: number;
+	currentItemCount: number;
+	addedItemCount: number;
+	removedItemCount: number;
+	creepCount: number;
+	driftCount: number;
+	totalScopeIncrease: number;
+	totalSlipDays: number;
+	overdueCount: number;
+	entropyScore: number;
+}
+
+/**
+ * Threshold evaluation state.
+ */
+interface ThresholdEvaluation {
+	creep: boolean;
+	drift: boolean;
+	entropy: boolean;
+}
+
+/**
+ * Detector result payload.
+ */
+interface DetectorResult {
+	status: "healthy" | "alert";
+	metadata: {
+		today: string;
+	};
+	thresholds: {
+		scopeIncreaseThresholdPct: number;
+		maxCreepFindings: number;
+		maxDriftFindings: number;
+		maxEntropyScore: number;
+	};
+	exceeded: ThresholdEvaluation;
+	metrics: RoadmapMetrics;
+	findings: {
+		creep: ScopeCreepFinding[];
+		drift: DriftFinding[];
+	};
+}
+
+/**
+ * CLI run result payload used by the main entrypoint.
+ */
+interface CliRunResult {
+	exitCode: number;
+	output?: string;
+	error?: string;
+}
+
+/**
+ * Runtime dependencies injected for deterministic testing.
+ */
+interface CliDependencies {
+	readTextFile: (path: string) => Promise<string>;
+	writeStdout: (message: string) => void;
+	writeStderr: (message: string) => void;
+	exit: (code: number) => void;
+}
+
+const DEFAULT_TODAY = "2026-01-01";
+const DEFAULT_SCOPE_INCREASE_THRESHOLD_PCT = 0;
+const DEFAULT_MAX_CREEP_FINDINGS = 0;
+const DEFAULT_MAX_DRIFT_FINDINGS = 0;
+const DEFAULT_MAX_ENTROPY_SCORE = 0;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const DONE_STATUSES = new Set(["done", "completed", "closed"]);
+
+/**
+ * Returns CLI usage instructions.
+ */
+function getUsageText(): string {
+	return [
+		"Usage: deno task roadmap-entropy -- --baseline <path> --current <path> [options]",
+		"",
+		"Options:",
+		"  --today <YYYY-MM-DD>                 Override the date used for overdue detection.",
+		"  --scope-increase-threshold-pct <n>   Minimum percent increase to flag scope creep.",
+		"  --max-creep-findings <n>             Maximum allowed creep findings before non-zero exit.",
+		"  --max-drift-findings <n>             Maximum allowed drift findings before non-zero exit.",
+		"  --max-entropy-score <n>              Maximum allowed entropy score before non-zero exit.",
+		"  --help                               Show this message.",
+	].join("\n");
+}
+
+/**
+ * Throws a prefixed option error.
+ */
+function throwOptionError(message: string): never {
+	throw new Error(`Invalid arguments: ${message}`);
+}
+
+/**
+ * Parses a non-negative number option value.
+ */
+function parseNonNegativeNumber(rawValue: string, optionName: string): number {
+	const value = Number(rawValue);
+	if (!Number.isFinite(value) || value < 0) {
+		throwOptionError(`${optionName} must be a non-negative number.`);
+	}
+
+	return value;
+}
+
+/**
+ * Reads the next argument as an option value.
+ */
+function getOptionValue(args: string[], index: number, optionName: string): string {
+	const value = args[index + 1];
+	if (!value || value.startsWith("--")) {
+		throwOptionError(`${optionName} requires a value.`);
+	}
+
+	return value;
+}
+
+/**
+ * Parses CLI arguments into detector options.
+ */
+function parseCliArgs(args: string[]): CliOptions | { help: true } {
+	let baselinePath = "";
+	let currentPath = "";
+	let today = DEFAULT_TODAY;
+	let scopeIncreaseThresholdPct = DEFAULT_SCOPE_INCREASE_THRESHOLD_PCT;
+	let maxCreepFindings = DEFAULT_MAX_CREEP_FINDINGS;
+	let maxDriftFindings = DEFAULT_MAX_DRIFT_FINDINGS;
+	let maxEntropyScore = DEFAULT_MAX_ENTROPY_SCORE;
+
+	for (let index = 0; index < args.length; index += 1) {
+		const arg = args[index];
+
+		switch (arg) {
+			case "--": {
+				break;
+			}
+			case "--help": {
+				return { help: true };
+			}
+			case "--baseline": {
+				baselinePath = getOptionValue(args, index, arg);
+				index += 1;
+				break;
+			}
+			case "--current": {
+				currentPath = getOptionValue(args, index, arg);
+				index += 1;
+				break;
+			}
+			case "--today": {
+				today = getOptionValue(args, index, arg);
+				index += 1;
+				break;
+			}
+			case "--scope-increase-threshold-pct": {
+				scopeIncreaseThresholdPct = parseNonNegativeNumber(getOptionValue(args, index, arg), arg);
+				index += 1;
+				break;
+			}
+			case "--max-creep-findings": {
+				maxCreepFindings = parseNonNegativeNumber(getOptionValue(args, index, arg), arg);
+				index += 1;
+				break;
+			}
+			case "--max-drift-findings": {
+				maxDriftFindings = parseNonNegativeNumber(getOptionValue(args, index, arg), arg);
+				index += 1;
+				break;
+			}
+			case "--max-entropy-score": {
+				maxEntropyScore = parseNonNegativeNumber(getOptionValue(args, index, arg), arg);
+				index += 1;
+				break;
+			}
+			default: {
+				throwOptionError(`unsupported option '${arg}'.`);
+			}
+		}
+	}
+
+	if (!baselinePath) {
+		throwOptionError("--baseline is required.");
+	}
+	if (!currentPath) {
+		throwOptionError("--current is required.");
+	}
+	if (!isValidDateString(today)) {
+		throwOptionError("--today must use YYYY-MM-DD format.");
+	}
+
+	return {
+		baselinePath,
+		currentPath,
+		today,
+		scopeIncreaseThresholdPct,
+		maxCreepFindings,
+		maxDriftFindings,
+		maxEntropyScore,
+	};
+}
+
+/**
+ * Validates date format and calendar correctness.
+ */
+function isValidDateString(value: string): boolean {
+	if (!DATE_PATTERN.test(value)) {
+		return false;
+	}
+
+	const parsed = Date.parse(`${value}T00:00:00Z`);
+	if (Number.isNaN(parsed)) {
+		return false;
+	}
+
+	const normalized = new Date(parsed).toISOString().slice(0, 10);
+	return normalized === value;
+}
+
+/**
+ * Converts YYYY-MM-DD to UTC epoch days.
+ */
+function toEpochDays(value: string, fieldName: string): number {
+	if (!isValidDateString(value)) {
+		throw new Error(`${fieldName} must use YYYY-MM-DD format.`);
+	}
+
+	const milliseconds = Date.parse(`${value}T00:00:00Z`);
+	return Math.floor(milliseconds / 86_400_000);
+}
+
+/**
+ * Casts a JSON value to a string-keyed object.
+ */
+function asObject(value: JsonValue, fieldName: string): { [key: string]: JsonValue } {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		throw new Error(`${fieldName} must be an object.`);
+	}
+
+	return value;
+}
+
+/**
+ * Reads and parses JSON content from disk.
+ */
+async function readJsonFile(path: string, readTextFile: (path: string) => Promise<string>): Promise<JsonValue> {
+	const rawText = await readTextFile(path);
+	try {
+		return JSON.parse(rawText) as JsonValue;
+	} catch {
+		throw new Error(`Could not parse JSON from '${path}'.`);
+	}
+}
+
+/**
+ * Validates that the provided value is a valid roadmap snapshot.
+ */
+function validateSnapshot(value: JsonValue, label: "baseline" | "current"): RoadmapSnapshot {
+	const snapshotObject = asObject(value, `${label} snapshot`);
+	const itemsValue = snapshotObject.items;
+
+	if (!Array.isArray(itemsValue)) {
+		throw new Error(`${label} snapshot items must be an array.`);
+	}
+
+	const items = itemsValue.map((itemValue, index) => {
+		return validateItem(itemValue, label, index);
+	});
+
+	const uniqueIds = new Set<string>();
+	for (const item of items) {
+		if (uniqueIds.has(item.id)) {
+			throw new Error(`${label} snapshot has duplicate item id '${item.id}'.`);
+		}
+		uniqueIds.add(item.id);
+	}
+
+	return { items };
+}
+
+/**
+ * Validates and normalizes a snapshot item.
+ */
+function validateItem(value: JsonValue, label: "baseline" | "current", index: number): RoadmapItem {
+	const itemObject = asObject(value, `${label} snapshot item at index ${index}`);
+
+	const id = itemObject.id;
+	if (typeof id !== "string" || id.trim() === "") {
+		throw new Error(`${label} snapshot item at index ${index} must have a non-empty id.`);
+	}
+
+	const status = itemObject.status;
+	if (typeof status !== "string" || status.trim() === "") {
+		throw new Error(`${label} snapshot item '${id}' must have a non-empty status.`);
+	}
+
+	const targetDate = itemObject.targetDate;
+	if (typeof targetDate !== "string") {
+		throw new Error(`${label} snapshot item '${id}' must have a targetDate string.`);
+	}
+
+	const targetDateEpochDays = toEpochDays(targetDate, `${label} snapshot item '${id}' targetDate`);
+	const scopeSize = getScopeSize(itemObject, label, id);
+
+	return {
+		id,
+		status,
+		targetDate,
+		targetDateEpochDays,
+		scopeSize,
+	};
+}
+
+/**
+ * Resolves scope size from scopePoints or tasks.length.
+ */
+function getScopeSize(itemObject: { [key: string]: JsonValue }, label: "baseline" | "current", id: string): number {
+	const scopePoints = itemObject.scopePoints;
+	if (typeof scopePoints === "number") {
+		if (!Number.isFinite(scopePoints) || scopePoints < 0) {
+			throw new Error(`${label} snapshot item '${id}' scopePoints must be a non-negative number.`);
+		}
+		return scopePoints;
+	}
+
+	const tasks = itemObject.tasks;
+	if (Array.isArray(tasks)) {
+		for (const task of tasks) {
+			if (typeof task !== "string") {
+				throw new Error(`${label} snapshot item '${id}' tasks must contain only strings.`);
+			}
+		}
+		return tasks.length;
+	}
+
+	throw new Error(`${label} snapshot item '${id}' must include scopePoints or tasks.`);
+}
+
+/**
+ * Returns positive day difference when end date is later than start date.
+ */
+function getSlipDays(startEpochDays: number, endEpochDays: number): number {
+	if (endEpochDays <= startEpochDays) {
+		return 0;
+	}
+
+	return endEpochDays - startEpochDays;
+}
+
+/**
+ * Indicates whether a status should be treated as incomplete.
+ */
+function isIncompleteStatus(status: string): boolean {
+	return !DONE_STATUSES.has(status.trim().toLowerCase());
+}
+
+/**
+ * Calculates scope increase percentage from baseline to current scope.
+ */
+function getIncreasePct(baselineScope: number, currentScope: number): number {
+	if (baselineScope === 0) {
+		return currentScope > 0 ? 100 : 0;
+	}
+
+	return Number((((currentScope - baselineScope) / baselineScope) * 100).toFixed(2));
+}
+
+/**
+ * Builds a map from item id to item for quick comparisons.
+ */
+function toItemMap(items: RoadmapItem[]): Map<string, RoadmapItem> {
+	const itemMap = new Map<string, RoadmapItem>();
+	for (const item of items) {
+		itemMap.set(item.id, item);
+	}
+	return itemMap;
+}
+
+/**
+ * Evaluates roadmap entropy findings and aggregate metrics.
+ */
+function detectRoadmapEntropy(
+	baseline: RoadmapSnapshot,
+	current: RoadmapSnapshot,
+	options: CliOptions,
+): DetectorResult {
+	const baselineMap = toItemMap(baseline.items);
+	const currentMap = toItemMap(current.items);
+	const creepFindings: ScopeCreepFinding[] = [];
+	const driftFindings: DriftFinding[] = [];
+	let addedItemCount = 0;
+	let removedItemCount = 0;
+	let totalScopeIncrease = 0;
+	let totalSlipDays = 0;
+	let overdueCount = 0;
+	const todayEpochDays = toEpochDays(options.today, "today");
+
+	for (const currentItem of current.items) {
+		const baselineItem = baselineMap.get(currentItem.id);
+
+		if (!baselineItem) {
+			addedItemCount += 1;
+			const newItemIncreasePct = getIncreasePct(0, currentItem.scopeSize);
+			if (newItemIncreasePct > options.scopeIncreaseThresholdPct) {
+				creepFindings.push({
+					type: "scope_creep",
+					id: currentItem.id,
+					increasePoints: currentItem.scopeSize,
+					increasePct: newItemIncreasePct,
+					baselineScope: 0,
+					currentScope: currentItem.scopeSize,
+					reason: "new_item",
+				});
+				totalScopeIncrease += currentItem.scopeSize;
+			}
+		} else {
+			const increasePoints = currentItem.scopeSize - baselineItem.scopeSize;
+			const increasePct = getIncreasePct(baselineItem.scopeSize, currentItem.scopeSize);
+			if (increasePoints > 0 && increasePct > options.scopeIncreaseThresholdPct) {
+				creepFindings.push({
+					type: "scope_creep",
+					id: currentItem.id,
+					increasePoints,
+					increasePct,
+					baselineScope: baselineItem.scopeSize,
+					currentScope: currentItem.scopeSize,
+					reason: "scope_increase",
+				});
+				totalScopeIncrease += increasePoints;
+			}
+		}
+
+		const baselineTargetEpochDays = baselineItem?.targetDateEpochDays ?? currentItem.targetDateEpochDays;
+		const baselineTargetDate = baselineItem?.targetDate ?? null;
+		const slipDays = getSlipDays(baselineTargetEpochDays, currentItem.targetDateEpochDays);
+		const overdue = isIncompleteStatus(currentItem.status) && todayEpochDays > currentItem.targetDateEpochDays;
+
+		if (slipDays > 0 || overdue) {
+			driftFindings.push({
+				type: "schedule_drift",
+				id: currentItem.id,
+				slipDays,
+				overdue,
+				baselineTargetDate,
+				currentTargetDate: currentItem.targetDate,
+				status: currentItem.status,
+			});
+			totalSlipDays += slipDays;
+			if (overdue) {
+				overdueCount += 1;
+			}
+		}
+	}
+
+	for (const baselineItem of baseline.items) {
+		if (!currentMap.has(baselineItem.id)) {
+			removedItemCount += 1;
+		}
+	}
+
+	const entropyScore = Number(
+		(creepFindings.length * 5 + driftFindings.length * 5 + totalSlipDays + totalScopeIncrease).toFixed(2),
+	);
+
+	const exceeded: ThresholdEvaluation = {
+		creep: creepFindings.length > options.maxCreepFindings,
+		drift: driftFindings.length > options.maxDriftFindings,
+		entropy: entropyScore > options.maxEntropyScore,
+	};
+
+	const status: DetectorResult["status"] = exceeded.creep || exceeded.drift || exceeded.entropy
+		? "alert"
+		: "healthy";
+
+	const metrics: RoadmapMetrics = {
+		baselineItemCount: baseline.items.length,
+		currentItemCount: current.items.length,
+		addedItemCount,
+		removedItemCount,
+		creepCount: creepFindings.length,
+		driftCount: driftFindings.length,
+		totalScopeIncrease,
+		totalSlipDays,
+		overdueCount,
+		entropyScore,
+	};
+
+	return {
+		status,
+		metadata: {
+			today: options.today,
+		},
+		thresholds: {
+			scopeIncreaseThresholdPct: options.scopeIncreaseThresholdPct,
+			maxCreepFindings: options.maxCreepFindings,
+			maxDriftFindings: options.maxDriftFindings,
+			maxEntropyScore: options.maxEntropyScore,
+		},
+		exceeded,
+		metrics,
+		findings: {
+			creep: creepFindings,
+			drift: driftFindings,
+		},
+	};
+}
+
+/**
+ * Returns CLI exit code for the detector result.
+ */
+function getExitCode(result: DetectorResult): number {
+	return result.exceeded.creep || result.exceeded.drift || result.exceeded.entropy ? 2 : 0;
+}
+
+/**
+ * Parses, validates, and evaluates entropy from roadmap snapshots.
+ */
+export async function runRoadmapEntropyDetectorCli(
+	args: string[],
+	readTextFile: (path: string) => Promise<string>,
+): Promise<CliRunResult> {
+	try {
+		const parsedArgs = parseCliArgs(args);
+		if ("help" in parsedArgs) {
+			return {
+				exitCode: 0,
+				output: getUsageText(),
+			};
+		}
+
+		const baselineValue = await readJsonFile(parsedArgs.baselinePath, readTextFile);
+		const currentValue = await readJsonFile(parsedArgs.currentPath, readTextFile);
+		const baselineSnapshot = validateSnapshot(baselineValue, "baseline");
+		const currentSnapshot = validateSnapshot(currentValue, "current");
+		const result = detectRoadmapEntropy(baselineSnapshot, currentSnapshot, parsedArgs);
+
+		return {
+			exitCode: getExitCode(result),
+			output: JSON.stringify(result, null, 2),
+		};
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		return {
+			exitCode: 1,
+			error: `Roadmap Entropy Detector error: ${message}`,
+		};
+	}
+}
+
+/**
+ * Executes CLI behavior when module runs as an entrypoint.
+ */
+export async function maybeRunMain(isMain: boolean, args: string[], dependencies: CliDependencies): Promise<void> {
+	if (!isMain) {
+		return;
+	}
+
+	const runResult = await runRoadmapEntropyDetectorCli(args, dependencies.readTextFile);
+	if (runResult.output) {
+		dependencies.writeStdout(runResult.output);
+	}
+	if (runResult.error) {
+		dependencies.writeStderr(runResult.error);
+	}
+	if (runResult.exitCode !== 0) {
+		dependencies.exit(runResult.exitCode);
+	}
+}
+
+await maybeRunMain(import.meta.main, Deno.args, {
+	readTextFile: Deno.readTextFile,
+	writeStdout: console.log,
+	writeStderr: console.error,
+	exit: Deno.exit,
+});

--- a/deno.json
+++ b/deno.json
@@ -29,6 +29,7 @@
 		"locale-check": "deno --allow-read --allow-write bin/find-invalid-variables.ts && deno --allow-read --allow-write bin/missing-locales.ts",
 		"locales": "deno task locale-check && deno task sort",
 		"bundle": "deno run -A bin/build.ts",
+		"roadmap-entropy": "deno run --allow-read bin/roadmap-entropy-detector.ts",
 		"checks": "deno task fmt && deno task lint && deno task test && deno task locales && deno task dev-firefox",
 
 		"dev-firefox": "deno --allow-write src/manifest/build-manifest.mjs firefox && deno task bundle",

--- a/docs/roadmap-entropy-detector.md
+++ b/docs/roadmap-entropy-detector.md
@@ -14,24 +14,25 @@ Both `--baseline` and `--current` must point to JSON files with this shape:
 
 ```json
 {
-  "items": [
-    {
-      "id": "ROADMAP-123",
-      "status": "in_progress",
-      "targetDate": "2026-05-15",
-      "scopePoints": 8
-    },
-    {
-      "id": "ROADMAP-456",
-      "status": "done",
-      "targetDate": "2026-04-02",
-      "tasks": ["task-1", "task-2"]
-    }
-  ]
+	"items": [
+		{
+			"id": "ROADMAP-123",
+			"status": "in_progress",
+			"targetDate": "2026-05-15",
+			"scopePoints": 8
+		},
+		{
+			"id": "ROADMAP-456",
+			"status": "done",
+			"targetDate": "2026-04-02",
+			"tasks": ["task-1", "task-2"]
+		}
+	]
 }
 ```
 
 Rules:
+
 - `id` must be unique per snapshot.
 - `targetDate` must use `YYYY-MM-DD`.
 - Scope is resolved from `scopePoints` when present, otherwise from `tasks.length`.
@@ -40,10 +41,12 @@ Rules:
 ## Detection Rules
 
 Scope creep:
+
 - Existing item scope increases above `--scope-increase-threshold-pct`.
 - New current-only items are treated as scope creep (`reason: "new_item"`) when they exceed the same threshold.
 
 Schedule drift:
+
 - `current.targetDate` slips later than `baseline.targetDate`.
 - Item is incomplete and the detector `today` date is after `current.targetDate`.
 
@@ -54,6 +57,7 @@ Schedule drift:
 - `2`: threshold breach.
 
 Threshold checks are strict `>` comparisons:
+
 - `--max-creep-findings` (default `0`)
 - `--max-drift-findings` (default `0`)
 - `--max-entropy-score` (default `0`)
@@ -73,36 +77,36 @@ Threshold checks are strict `>` comparisons:
 
 ```json
 {
-  "status": "alert",
-  "metadata": {
-    "today": "2026-03-31"
-  },
-  "thresholds": {
-    "scopeIncreaseThresholdPct": 0,
-    "maxCreepFindings": 0,
-    "maxDriftFindings": 0,
-    "maxEntropyScore": 0
-  },
-  "exceeded": {
-    "creep": true,
-    "drift": true,
-    "entropy": true
-  },
-  "metrics": {
-    "baselineItemCount": 1,
-    "currentItemCount": 2,
-    "addedItemCount": 1,
-    "removedItemCount": 0,
-    "creepCount": 2,
-    "driftCount": 2,
-    "totalScopeIncrease": 4,
-    "totalSlipDays": 9,
-    "overdueCount": 2,
-    "entropyScore": 33
-  },
-  "findings": {
-    "creep": [],
-    "drift": []
-  }
+	"status": "alert",
+	"metadata": {
+		"today": "2026-03-31"
+	},
+	"thresholds": {
+		"scopeIncreaseThresholdPct": 0,
+		"maxCreepFindings": 0,
+		"maxDriftFindings": 0,
+		"maxEntropyScore": 0
+	},
+	"exceeded": {
+		"creep": true,
+		"drift": true,
+		"entropy": true
+	},
+	"metrics": {
+		"baselineItemCount": 1,
+		"currentItemCount": 2,
+		"addedItemCount": 1,
+		"removedItemCount": 0,
+		"creepCount": 2,
+		"driftCount": 2,
+		"totalScopeIncrease": 4,
+		"totalSlipDays": 9,
+		"overdueCount": 2,
+		"entropyScore": 33
+	},
+	"findings": {
+		"creep": [],
+		"drift": []
+	}
 }
 ```

--- a/docs/roadmap-entropy-detector.md
+++ b/docs/roadmap-entropy-detector.md
@@ -1,0 +1,108 @@
+# Roadmap Entropy Detector
+
+`roadmap-entropy-detector` is a Deno CLI that compares a baseline roadmap snapshot with a current snapshot and reports scope creep and schedule drift.
+
+## Run
+
+```bash
+deno task roadmap-entropy -- --baseline ./baseline.json --current ./current.json
+```
+
+## Input Schema
+
+Both `--baseline` and `--current` must point to JSON files with this shape:
+
+```json
+{
+  "items": [
+    {
+      "id": "ROADMAP-123",
+      "status": "in_progress",
+      "targetDate": "2026-05-15",
+      "scopePoints": 8
+    },
+    {
+      "id": "ROADMAP-456",
+      "status": "done",
+      "targetDate": "2026-04-02",
+      "tasks": ["task-1", "task-2"]
+    }
+  ]
+}
+```
+
+Rules:
+- `id` must be unique per snapshot.
+- `targetDate` must use `YYYY-MM-DD`.
+- Scope is resolved from `scopePoints` when present, otherwise from `tasks.length`.
+- Each item must provide either `scopePoints` or `tasks`.
+
+## Detection Rules
+
+Scope creep:
+- Existing item scope increases above `--scope-increase-threshold-pct`.
+- New current-only items are treated as scope creep (`reason: "new_item"`) when they exceed the same threshold.
+
+Schedule drift:
+- `current.targetDate` slips later than `baseline.targetDate`.
+- Item is incomplete and the detector `today` date is after `current.targetDate`.
+
+## Exit Codes
+
+- `0`: healthy or within configured thresholds.
+- `1`: invalid arguments/input schema/JSON parse error.
+- `2`: threshold breach.
+
+Threshold checks are strict `>` comparisons:
+- `--max-creep-findings` (default `0`)
+- `--max-drift-findings` (default `0`)
+- `--max-entropy-score` (default `0`)
+
+## Options
+
+- `--baseline <path>` (required)
+- `--current <path>` (required)
+- `--today <YYYY-MM-DD>` (default `2026-01-01`)
+- `--scope-increase-threshold-pct <number>` (default `0`)
+- `--max-creep-findings <number>` (default `0`)
+- `--max-drift-findings <number>` (default `0`)
+- `--max-entropy-score <number>` (default `0`)
+- `--help`
+
+## Example Output
+
+```json
+{
+  "status": "alert",
+  "metadata": {
+    "today": "2026-03-31"
+  },
+  "thresholds": {
+    "scopeIncreaseThresholdPct": 0,
+    "maxCreepFindings": 0,
+    "maxDriftFindings": 0,
+    "maxEntropyScore": 0
+  },
+  "exceeded": {
+    "creep": true,
+    "drift": true,
+    "entropy": true
+  },
+  "metrics": {
+    "baselineItemCount": 1,
+    "currentItemCount": 2,
+    "addedItemCount": 1,
+    "removedItemCount": 0,
+    "creepCount": 2,
+    "driftCount": 2,
+    "totalScopeIncrease": 4,
+    "totalSlipDays": 9,
+    "overdueCount": 2,
+    "entropyScore": 33
+  },
+  "findings": {
+    "creep": [],
+    "drift": []
+  }
+}
+```

--- a/src/action/variables.css
+++ b/src/action/variables.css
@@ -1,8 +1,8 @@
 html {
 	--white: #ffffff;
-	--rgbwhite: 255,255,255;
+	--rgbwhite: 255, 255, 255;
 	--black: #000000;
-	--rgbblack: 0,0,0;
+	--rgbblack: 0, 0, 0;
 	--green: #82c4b2;
 	--midgreen: #4ea68f;
 	--darkgreen: #346f5f;

--- a/src/manifest/template-manifest.json
+++ b/src/manifest/template-manifest.json
@@ -79,9 +79,9 @@
 			"id": "again@why.salesforce",
 			"strict_min_version": "140.0",
 			"data_collection_permissions": {
-                "required": [
-                  "none"
-                ],
+				"required": [
+					"none"
+				],
 				"optional": [
 					"technicalAndInteraction"
 				]

--- a/src/salesforce/favourite-manager.js
+++ b/src/salesforce/favourite-manager.js
@@ -17,7 +17,11 @@ import {
 	WHAT_ADD,
 	WHAT_GET_COMMANDS,
 } from "/core/constants.js";
-import { getSettings, injectStyle, sendExtensionMessage } from "/core/functions.js";
+import {
+	getSettings,
+	injectStyle,
+	sendExtensionMessage,
+} from "/core/functions.js";
 import Tab from "/core/tab.js";
 import { ensureAllTabsAvailability } from "/core/tabContainer.js";
 import ensureTranslatorAvailability from "/core/translator.js";

--- a/src/salesforce/manageTabs.js
+++ b/src/salesforce/manageTabs.js
@@ -11,7 +11,10 @@ import {
 	TUTORIAL_EVENT_CREATE_MANAGE_TABS_MODAL,
 	TUTORIAL_EVENT_REORDERED_TABS_TABLE,
 } from "/core/constants.js";
-import { getInnerElementFieldBySelector, injectStyle } from "/core/functions.js";
+import {
+	getInnerElementFieldBySelector,
+	injectStyle,
+} from "/core/functions.js";
 import Tab from "/core/tab.js";
 import { ensureAllTabsAvailability, TabContainer } from "/core/tabContainer.js";
 import ensureTranslatorAvailability from "/core/translator.js";

--- a/tests/bin/roadmap-entropy-detector.test.ts
+++ b/tests/bin/roadmap-entropy-detector.test.ts
@@ -1,0 +1,598 @@
+import {
+	assert,
+	assertEquals,
+	assertStringIncludes,
+} from "@std/testing/asserts";
+import {
+	maybeRunMain,
+	runRoadmapEntropyDetectorCli,
+} from "../../bin/roadmap-entropy-detector.ts";
+
+/**
+ * Creates an async file reader backed by in-memory content.
+ */
+function createReadTextFile(fileMap: Record<string, string>): (path: string) => Promise<string> {
+	return (path: string): Promise<string> => {
+		const file = fileMap[path];
+		if (!file) {
+			return Promise.reject(new Error(`ENOENT: '${path}'`));
+		}
+		return Promise.resolve(file);
+	};
+}
+
+/**
+ * Parses detector JSON output and returns the parsed object.
+ */
+function parseDetectorOutput(output: string | undefined): Record<string, number | string | object> {
+	assert(output, "expected detector output");
+	return JSON.parse(output);
+}
+
+/**
+ * Builds a JSON file map for baseline/current snapshots.
+ */
+function createSnapshotFiles(baseline: object, current: object): Record<string, string> {
+	return {
+		"./baseline.json": JSON.stringify(baseline),
+		"./current.json": JSON.stringify(current),
+	};
+}
+
+Deno.test("returns help text", async () => {
+	const result = await runRoadmapEntropyDetectorCli(["--help"], createReadTextFile({}));
+
+	assertEquals(result.exitCode, 0);
+	assert(result.output);
+	assertStringIncludes(result.output, "Usage: deno task roadmap-entropy");
+});
+
+Deno.test("supports deno task delimiter before options", async () => {
+	const result = await runRoadmapEntropyDetectorCli(["--", "--help"], createReadTextFile({}));
+
+	assertEquals(result.exitCode, 0);
+	assert(result.output);
+	assertStringIncludes(result.output, "Usage: deno task roadmap-entropy");
+});
+
+Deno.test("detects unchanged roadmap as healthy", async () => {
+	const files = createSnapshotFiles(
+		{
+			items: [{ id: "A", status: "in_progress", targetDate: "2026-04-10", scopePoints: 3 }],
+		},
+		{
+			items: [{ id: "A", status: "in_progress", targetDate: "2026-04-10", scopePoints: 3 }],
+		},
+	);
+
+	const result = await runRoadmapEntropyDetectorCli(
+		[
+			"--baseline",
+			"./baseline.json",
+			"--current",
+			"./current.json",
+			"--today",
+			"2026-04-01",
+		],
+		createReadTextFile(files),
+	);
+
+	assertEquals(result.exitCode, 0);
+	const output = parseDetectorOutput(result.output);
+	assertEquals(output.status, "healthy");
+	assertEquals((output.metrics as Record<string, number>).creepCount, 0);
+	assertEquals((output.metrics as Record<string, number>).driftCount, 0);
+});
+
+Deno.test("flags scope creep and exits non-zero with strict thresholds", async () => {
+	const files = createSnapshotFiles(
+		{
+			items: [{ id: "A", status: "in_progress", targetDate: "2026-05-01", scopePoints: 2 }],
+		},
+		{
+			items: [{ id: "A", status: "in_progress", targetDate: "2026-05-01", scopePoints: 4 }],
+		},
+	);
+
+	const result = await runRoadmapEntropyDetectorCli(
+		["--baseline", "./baseline.json", "--current", "./current.json", "--today", "2026-04-01"],
+		createReadTextFile(files),
+	);
+
+	assertEquals(result.exitCode, 2);
+	const output = parseDetectorOutput(result.output);
+	assertEquals((output.metrics as Record<string, number>).creepCount, 1);
+	assertEquals((output.metrics as Record<string, number>).driftCount, 0);
+	const creepFindings = (output.findings as Record<string, object>).creep as Array<Record<string, string | number>>;
+	assertEquals(creepFindings[0].reason, "scope_increase");
+});
+
+Deno.test("flags drift-only via target-date slip", async () => {
+	const files = createSnapshotFiles(
+		{
+			items: [{ id: "A", status: "done", targetDate: "2026-04-01", tasks: ["T1", "T2"] }],
+		},
+		{
+			items: [{ id: "A", status: "done", targetDate: "2026-04-05", tasks: ["T1", "T2"] }],
+		},
+	);
+
+	const result = await runRoadmapEntropyDetectorCli(
+		[
+			"--baseline",
+			"./baseline.json",
+			"--current",
+			"./current.json",
+			"--today",
+			"2026-04-01",
+			"--max-creep-findings",
+			"10",
+		],
+		createReadTextFile(files),
+	);
+
+	assertEquals(result.exitCode, 2);
+	const output = parseDetectorOutput(result.output);
+	assertEquals((output.metrics as Record<string, number>).creepCount, 0);
+	assertEquals((output.metrics as Record<string, number>).driftCount, 1);
+	const driftFindings = (output.findings as Record<string, object>).drift as Array<Record<string, string | number | boolean>>;
+	assertEquals(driftFindings[0].slipDays, 4);
+	assertEquals(driftFindings[0].overdue, false);
+});
+
+Deno.test("handles mixed findings and entropy threshold gate", async () => {
+	const files = createSnapshotFiles(
+		{
+			items: [{ id: "A", status: "in_progress", targetDate: "2026-03-01", scopePoints: 1 }],
+		},
+		{
+			items: [
+				{ id: "A", status: "in_progress", targetDate: "2026-03-10", scopePoints: 3 },
+				{ id: "B", status: "blocked", targetDate: "2026-02-01", scopePoints: 2 },
+			],
+		},
+	);
+
+	const result = await runRoadmapEntropyDetectorCli(
+		[
+			"--baseline",
+			"./baseline.json",
+			"--current",
+			"./current.json",
+			"--today",
+			"2026-03-31",
+			"--max-creep-findings",
+			"5",
+			"--max-drift-findings",
+			"5",
+			"--max-entropy-score",
+			"5",
+		],
+		createReadTextFile(files),
+	);
+
+	assertEquals(result.exitCode, 2);
+	const output = parseDetectorOutput(result.output);
+	assertEquals(output.status, "alert");
+	assertEquals((output.metrics as Record<string, number>).creepCount, 2);
+	assertEquals((output.metrics as Record<string, number>).driftCount, 2);
+	assertEquals((output.exceeded as Record<string, boolean>).entropy, true);
+	assertEquals((output.exceeded as Record<string, boolean>).creep, false);
+	assertEquals((output.exceeded as Record<string, boolean>).drift, false);
+});
+
+Deno.test("supports threshold equality as healthy and stricter threshold as alert", async () => {
+	const files = createSnapshotFiles(
+		{
+			items: [{ id: "A", status: "in_progress", targetDate: "2026-06-01", scopePoints: 1 }],
+		},
+		{
+			items: [{ id: "A", status: "in_progress", targetDate: "2026-06-01", scopePoints: 2 }],
+		},
+	);
+
+	const healthyResult = await runRoadmapEntropyDetectorCli(
+		[
+			"--baseline",
+			"./baseline.json",
+			"--current",
+			"./current.json",
+			"--today",
+			"2026-05-01",
+			"--max-creep-findings",
+			"1",
+			"--max-entropy-score",
+			"999",
+		],
+		createReadTextFile(files),
+	);
+	assertEquals(healthyResult.exitCode, 0);
+
+	const alertResult = await runRoadmapEntropyDetectorCli(
+		[
+			"--baseline",
+			"./baseline.json",
+			"--current",
+			"./current.json",
+			"--today",
+			"2026-05-01",
+			"--max-creep-findings",
+			"0",
+			"--max-entropy-score",
+			"999",
+		],
+		createReadTextFile(files),
+	);
+	assertEquals(alertResult.exitCode, 2);
+});
+
+Deno.test("tracks removed items and respects scope threshold option", async () => {
+	const files = createSnapshotFiles(
+		{
+			items: [
+				{ id: "A", status: "done", targetDate: "2026-01-01", scopePoints: 2 },
+				{ id: "B", status: "done", targetDate: "2026-01-01", scopePoints: 1 },
+			],
+		},
+		{
+			items: [{ id: "A", status: "done", targetDate: "2026-01-01", scopePoints: 3 }],
+		},
+	);
+
+	const result = await runRoadmapEntropyDetectorCli(
+		[
+			"--baseline",
+			"./baseline.json",
+			"--current",
+			"./current.json",
+			"--scope-increase-threshold-pct",
+			"60",
+			"--max-creep-findings",
+			"10",
+			"--max-drift-findings",
+			"10",
+			"--max-entropy-score",
+			"999",
+		],
+		createReadTextFile(files),
+	);
+
+	assertEquals(result.exitCode, 0);
+	const output = parseDetectorOutput(result.output);
+	assertEquals((output.metrics as Record<string, number>).removedItemCount, 1);
+	assertEquals((output.metrics as Record<string, number>).creepCount, 0);
+});
+
+Deno.test("handles zero baseline and zero current scope without creep", async () => {
+	const files = createSnapshotFiles(
+		{
+			items: [{ id: "A", status: "done", targetDate: "2026-01-01", scopePoints: 0 }],
+		},
+		{
+			items: [{ id: "A", status: "done", targetDate: "2026-01-01", scopePoints: 0 }],
+		},
+	);
+
+	const result = await runRoadmapEntropyDetectorCli(
+		[
+			"--baseline",
+			"./baseline.json",
+			"--current",
+			"./current.json",
+			"--max-entropy-score",
+			"999",
+		],
+		createReadTextFile(files),
+	);
+
+	assertEquals(result.exitCode, 0);
+	const output = parseDetectorOutput(result.output);
+	assertEquals((output.metrics as Record<string, number>).creepCount, 0);
+});
+
+Deno.test("returns error for malformed schema", async () => {
+	const files = {
+		"./baseline.json": JSON.stringify({ items: { id: "A" } }),
+		"./current.json": JSON.stringify({ items: [] }),
+	};
+
+	const result = await runRoadmapEntropyDetectorCli(
+		["--baseline", "./baseline.json", "--current", "./current.json"],
+		createReadTextFile(files),
+	);
+
+	assertEquals(result.exitCode, 1);
+	assert(result.error);
+	assertStringIncludes(result.error, "baseline snapshot items must be an array");
+});
+
+Deno.test("returns error when snapshot root is not an object", async () => {
+	const result = await runRoadmapEntropyDetectorCli(
+		["--baseline", "./baseline.json", "--current", "./current.json"],
+		createReadTextFile({ "./baseline.json": "[]", "./current.json": "{\"items\":[]}" }),
+	);
+
+	assertEquals(result.exitCode, 1);
+	assert(result.error);
+	assertStringIncludes(result.error, "baseline snapshot must be an object");
+});
+
+Deno.test("returns error for duplicate ids", async () => {
+	const files = createSnapshotFiles(
+		{
+			items: [
+				{ id: "A", status: "done", targetDate: "2026-01-01", scopePoints: 1 },
+				{ id: "A", status: "done", targetDate: "2026-01-01", scopePoints: 1 },
+			],
+		},
+		{
+			items: [{ id: "A", status: "done", targetDate: "2026-01-01", scopePoints: 1 }],
+		},
+	);
+
+	const result = await runRoadmapEntropyDetectorCli(
+		["--baseline", "./baseline.json", "--current", "./current.json"],
+		createReadTextFile(files),
+	);
+
+	assertEquals(result.exitCode, 1);
+	assert(result.error);
+	assertStringIncludes(result.error, "duplicate item id");
+});
+
+Deno.test("returns error for missing id and invalid option values", async () => {
+	const files = createSnapshotFiles(
+		{
+			items: [{ id: "A", status: "done", targetDate: "2026-01-01", scopePoints: 1 }],
+		},
+		{
+			items: [{ status: "done", targetDate: "2026-01-01", scopePoints: 1 }],
+		},
+	);
+
+	const missingIdResult = await runRoadmapEntropyDetectorCli(
+		["--baseline", "./baseline.json", "--current", "./current.json"],
+		createReadTextFile(files),
+	);
+	assertEquals(missingIdResult.exitCode, 1);
+	assert(missingIdResult.error);
+	assertStringIncludes(missingIdResult.error, "non-empty id");
+
+	const invalidOptionResult = await runRoadmapEntropyDetectorCli(
+		["--baseline", "./baseline.json", "--current", "./current.json", "--max-drift-findings", "-1"],
+		createReadTextFile(files),
+	);
+	assertEquals(invalidOptionResult.exitCode, 1);
+	assert(invalidOptionResult.error);
+	assertStringIncludes(invalidOptionResult.error, "non-negative number");
+});
+
+Deno.test("returns error for missing baseline option", async () => {
+	const result = await runRoadmapEntropyDetectorCli(
+		["--current", "./current.json"],
+		createReadTextFile({ "./current.json": JSON.stringify({ items: [] }) }),
+	);
+
+	assertEquals(result.exitCode, 1);
+	assert(result.error);
+	assertStringIncludes(result.error, "--baseline is required");
+});
+
+Deno.test("returns error for missing scope and invalid tasks payload", async () => {
+	const filesMissingScope = createSnapshotFiles(
+		{
+			items: [{ id: "A", status: "done", targetDate: "2026-01-01", scopePoints: 1 }],
+		},
+		{
+			items: [{ id: "A", status: "done", targetDate: "2026-01-01" }],
+		},
+	);
+
+	const missingScopeResult = await runRoadmapEntropyDetectorCli(
+		["--baseline", "./baseline.json", "--current", "./current.json"],
+		createReadTextFile(filesMissingScope),
+	);
+	assertEquals(missingScopeResult.exitCode, 1);
+	assert(missingScopeResult.error);
+	assertStringIncludes(missingScopeResult.error, "scopePoints or tasks");
+
+	const filesInvalidTasks = createSnapshotFiles(
+		{
+			items: [{ id: "A", status: "done", targetDate: "2026-01-01", tasks: ["x"] }],
+		},
+		{
+			items: [{ id: "A", status: "done", targetDate: "2026-01-01", tasks: ["x", 1] }],
+		},
+	);
+
+	const invalidTasksResult = await runRoadmapEntropyDetectorCli(
+		["--baseline", "./baseline.json", "--current", "./current.json"],
+		createReadTextFile(filesInvalidTasks),
+	);
+	assertEquals(invalidTasksResult.exitCode, 1);
+	assert(invalidTasksResult.error);
+	assertStringIncludes(invalidTasksResult.error, "tasks must contain only strings");
+});
+
+Deno.test("returns error for empty status, invalid targetDate type, and negative scopePoints", async () => {
+	const emptyStatusResult = await runRoadmapEntropyDetectorCli(
+		["--baseline", "./baseline.json", "--current", "./current.json"],
+		createReadTextFile({
+			"./baseline.json": JSON.stringify({
+				items: [{ id: "A", status: "", targetDate: "2026-01-01", scopePoints: 1 }],
+			}),
+			"./current.json": JSON.stringify({ items: [] }),
+		}),
+	);
+	assertEquals(emptyStatusResult.exitCode, 1);
+	assert(emptyStatusResult.error);
+	assertStringIncludes(emptyStatusResult.error, "non-empty status");
+
+	const invalidTargetDateTypeResult = await runRoadmapEntropyDetectorCli(
+		["--baseline", "./baseline.json", "--current", "./current.json"],
+		createReadTextFile({
+			"./baseline.json": JSON.stringify({
+				items: [{ id: "A", status: "done", targetDate: 1, scopePoints: 1 }],
+			}),
+			"./current.json": JSON.stringify({ items: [] }),
+		}),
+	);
+	assertEquals(invalidTargetDateTypeResult.exitCode, 1);
+	assert(invalidTargetDateTypeResult.error);
+	assertStringIncludes(invalidTargetDateTypeResult.error, "targetDate string");
+
+	const negativeScopeResult = await runRoadmapEntropyDetectorCli(
+		["--baseline", "./baseline.json", "--current", "./current.json"],
+		createReadTextFile({
+			"./baseline.json": JSON.stringify({
+				items: [{ id: "A", status: "done", targetDate: "2026-01-01", scopePoints: -1 }],
+			}),
+			"./current.json": JSON.stringify({ items: [] }),
+		}),
+	);
+	assertEquals(negativeScopeResult.exitCode, 1);
+	assert(negativeScopeResult.error);
+	assertStringIncludes(negativeScopeResult.error, "non-negative number");
+});
+
+Deno.test("returns error for invalid date strings and invalid json", async () => {
+	const filesInvalidDate = createSnapshotFiles(
+		{
+			items: [{ id: "A", status: "done", targetDate: "2026-13-01", scopePoints: 1 }],
+		},
+		{
+			items: [{ id: "A", status: "done", targetDate: "2026-01-01", scopePoints: 1 }],
+		},
+	);
+
+	const invalidDateResult = await runRoadmapEntropyDetectorCli(
+		["--baseline", "./baseline.json", "--current", "./current.json"],
+		createReadTextFile(filesInvalidDate),
+	);
+	assertEquals(invalidDateResult.exitCode, 1);
+	assert(invalidDateResult.error);
+	assertStringIncludes(invalidDateResult.error, "YYYY-MM-DD");
+
+	const invalidTodayResult = await runRoadmapEntropyDetectorCli(
+		[
+			"--baseline",
+			"./baseline.json",
+			"--current",
+			"./current.json",
+			"--today",
+			"bad-date",
+		],
+		createReadTextFile(createSnapshotFiles({ items: [] }, { items: [] })),
+	);
+	assertEquals(invalidTodayResult.exitCode, 1);
+	assert(invalidTodayResult.error);
+	assertStringIncludes(invalidTodayResult.error, "--today must use YYYY-MM-DD format");
+
+	const invalidJsonResult = await runRoadmapEntropyDetectorCli(
+		["--baseline", "./baseline.json", "--current", "./current.json"],
+		createReadTextFile({ "./baseline.json": "{", "./current.json": "{}" }),
+	);
+	assertEquals(invalidJsonResult.exitCode, 1);
+	assert(invalidJsonResult.error);
+	assertStringIncludes(invalidJsonResult.error, "Could not parse JSON");
+});
+
+Deno.test("handles non-Error throws in catch path", async () => {
+	const result = await runRoadmapEntropyDetectorCli(
+		["--baseline", "./baseline.json", "--current", "./current.json"],
+		(): Promise<string> => Promise.reject("raw-failure"),
+	);
+
+	assertEquals(result.exitCode, 1);
+	assert(result.error);
+	assertStringIncludes(result.error, "raw-failure");
+});
+
+Deno.test("returns argument errors for unsupported and incomplete options", async () => {
+	const unsupportedResult = await runRoadmapEntropyDetectorCli(["--wat"], createReadTextFile({}));
+	assertEquals(unsupportedResult.exitCode, 1);
+	assert(unsupportedResult.error);
+	assertStringIncludes(unsupportedResult.error, "unsupported option");
+
+	const missingValueResult = await runRoadmapEntropyDetectorCli(["--baseline"], createReadTextFile({}));
+	assertEquals(missingValueResult.exitCode, 1);
+	assert(missingValueResult.error);
+	assertStringIncludes(missingValueResult.error, "requires a value");
+
+	const missingCurrentResult = await runRoadmapEntropyDetectorCli(
+		["--baseline", "./baseline.json"],
+		createReadTextFile({ "./baseline.json": JSON.stringify({ items: [] }) }),
+	);
+	assertEquals(missingCurrentResult.exitCode, 1);
+	assert(missingCurrentResult.error);
+	assertStringIncludes(missingCurrentResult.error, "--current is required");
+});
+
+Deno.test("maybeRunMain is a no-op when not running as main", async () => {
+	let stdout = "";
+	let stderr = "";
+	let exitCode = -1;
+
+	await maybeRunMain(false, ["--help"], {
+		readTextFile: (): Promise<string> => Promise.resolve(""),
+		writeStdout: (message: string): void => {
+			stdout = message;
+		},
+		writeStderr: (message: string): void => {
+			stderr = message;
+		},
+		exit: (code: number): void => {
+			exitCode = code;
+		},
+	});
+
+	assertEquals(stdout, "");
+	assertEquals(stderr, "");
+	assertEquals(exitCode, -1);
+});
+
+Deno.test("maybeRunMain writes output for success and does not exit", async () => {
+	let stdout = "";
+	let stderr = "";
+	let exitCode = -1;
+
+	await maybeRunMain(true, ["--help"], {
+		readTextFile: (): Promise<string> => Promise.resolve(""),
+		writeStdout: (message: string): void => {
+			stdout = message;
+		},
+		writeStderr: (message: string): void => {
+			stderr = message;
+		},
+		exit: (code: number): void => {
+			exitCode = code;
+		},
+	});
+
+	assertStringIncludes(stdout, "Usage: deno task roadmap-entropy");
+	assertEquals(stderr, "");
+	assertEquals(exitCode, -1);
+});
+
+Deno.test("maybeRunMain writes stderr and exits for errors", async () => {
+	let stdout = "";
+	let stderr = "";
+	let exitCode = -1;
+
+	await maybeRunMain(true, ["--baseline"], {
+		readTextFile: (): Promise<string> => Promise.resolve(""),
+		writeStdout: (message: string): void => {
+			stdout = message;
+		},
+		writeStderr: (message: string): void => {
+			stderr = message;
+		},
+		exit: (code: number): void => {
+			exitCode = code;
+		},
+	});
+
+	assertEquals(stdout, "");
+	assertStringIncludes(stderr, "Invalid arguments");
+	assertEquals(exitCode, 1);
+});

--- a/tests/bin/roadmap-entropy-detector.test.ts
+++ b/tests/bin/roadmap-entropy-detector.test.ts
@@ -11,7 +11,9 @@ import {
 /**
  * Creates an async file reader backed by in-memory content.
  */
-function createReadTextFile(fileMap: Record<string, string>): (path: string) => Promise<string> {
+function createReadTextFile(
+	fileMap: Record<string, string>,
+): (path: string) => Promise<string> {
 	return (path: string): Promise<string> => {
 		const file = fileMap[path];
 		if (!file) {
@@ -24,7 +26,9 @@ function createReadTextFile(fileMap: Record<string, string>): (path: string) => 
 /**
  * Parses detector JSON output and returns the parsed object.
  */
-function parseDetectorOutput(output: string | undefined): Record<string, number | string | object> {
+function parseDetectorOutput(
+	output: string | undefined,
+): Record<string, number | string | object> {
 	assert(output, "expected detector output");
 	return JSON.parse(output);
 }
@@ -32,7 +36,10 @@ function parseDetectorOutput(output: string | undefined): Record<string, number 
 /**
  * Builds a JSON file map for baseline/current snapshots.
  */
-function createSnapshotFiles(baseline: object, current: object): Record<string, string> {
+function createSnapshotFiles(
+	baseline: object,
+	current: object,
+): Record<string, string> {
 	return {
 		"./baseline.json": JSON.stringify(baseline),
 		"./current.json": JSON.stringify(current),
@@ -40,7 +47,10 @@ function createSnapshotFiles(baseline: object, current: object): Record<string, 
 }
 
 Deno.test("returns help text", async () => {
-	const result = await runRoadmapEntropyDetectorCli(["--help"], createReadTextFile({}));
+	const result = await runRoadmapEntropyDetectorCli(
+		["--help"],
+		createReadTextFile({}),
+	);
 
 	assertEquals(result.exitCode, 0);
 	assert(result.output);
@@ -48,7 +58,10 @@ Deno.test("returns help text", async () => {
 });
 
 Deno.test("supports deno task delimiter before options", async () => {
-	const result = await runRoadmapEntropyDetectorCli(["--", "--help"], createReadTextFile({}));
+	const result = await runRoadmapEntropyDetectorCli(
+		["--", "--help"],
+		createReadTextFile({}),
+	);
 
 	assertEquals(result.exitCode, 0);
 	assert(result.output);
@@ -58,10 +71,20 @@ Deno.test("supports deno task delimiter before options", async () => {
 Deno.test("detects unchanged roadmap as healthy", async () => {
 	const files = createSnapshotFiles(
 		{
-			items: [{ id: "A", status: "in_progress", targetDate: "2026-04-10", scopePoints: 3 }],
+			items: [{
+				id: "A",
+				status: "in_progress",
+				targetDate: "2026-04-10",
+				scopePoints: 3,
+			}],
 		},
 		{
-			items: [{ id: "A", status: "in_progress", targetDate: "2026-04-10", scopePoints: 3 }],
+			items: [{
+				id: "A",
+				status: "in_progress",
+				targetDate: "2026-04-10",
+				scopePoints: 3,
+			}],
 		},
 	);
 
@@ -87,15 +110,32 @@ Deno.test("detects unchanged roadmap as healthy", async () => {
 Deno.test("flags scope creep and exits non-zero with strict thresholds", async () => {
 	const files = createSnapshotFiles(
 		{
-			items: [{ id: "A", status: "in_progress", targetDate: "2026-05-01", scopePoints: 2 }],
+			items: [{
+				id: "A",
+				status: "in_progress",
+				targetDate: "2026-05-01",
+				scopePoints: 2,
+			}],
 		},
 		{
-			items: [{ id: "A", status: "in_progress", targetDate: "2026-05-01", scopePoints: 4 }],
+			items: [{
+				id: "A",
+				status: "in_progress",
+				targetDate: "2026-05-01",
+				scopePoints: 4,
+			}],
 		},
 	);
 
 	const result = await runRoadmapEntropyDetectorCli(
-		["--baseline", "./baseline.json", "--current", "./current.json", "--today", "2026-04-01"],
+		[
+			"--baseline",
+			"./baseline.json",
+			"--current",
+			"./current.json",
+			"--today",
+			"2026-04-01",
+		],
 		createReadTextFile(files),
 	);
 
@@ -103,17 +143,28 @@ Deno.test("flags scope creep and exits non-zero with strict thresholds", async (
 	const output = parseDetectorOutput(result.output);
 	assertEquals((output.metrics as Record<string, number>).creepCount, 1);
 	assertEquals((output.metrics as Record<string, number>).driftCount, 0);
-	const creepFindings = (output.findings as Record<string, object>).creep as Array<Record<string, string | number>>;
+	const creepFindings = (output.findings as Record<string, object>)
+		.creep as Array<Record<string, string | number>>;
 	assertEquals(creepFindings[0].reason, "scope_increase");
 });
 
 Deno.test("flags drift-only via target-date slip", async () => {
 	const files = createSnapshotFiles(
 		{
-			items: [{ id: "A", status: "done", targetDate: "2026-04-01", tasks: ["T1", "T2"] }],
+			items: [{
+				id: "A",
+				status: "done",
+				targetDate: "2026-04-01",
+				tasks: ["T1", "T2"],
+			}],
 		},
 		{
-			items: [{ id: "A", status: "done", targetDate: "2026-04-05", tasks: ["T1", "T2"] }],
+			items: [{
+				id: "A",
+				status: "done",
+				targetDate: "2026-04-05",
+				tasks: ["T1", "T2"],
+			}],
 		},
 	);
 
@@ -135,7 +186,8 @@ Deno.test("flags drift-only via target-date slip", async () => {
 	const output = parseDetectorOutput(result.output);
 	assertEquals((output.metrics as Record<string, number>).creepCount, 0);
 	assertEquals((output.metrics as Record<string, number>).driftCount, 1);
-	const driftFindings = (output.findings as Record<string, object>).drift as Array<Record<string, string | number | boolean>>;
+	const driftFindings = (output.findings as Record<string, object>)
+		.drift as Array<Record<string, string | number | boolean>>;
 	assertEquals(driftFindings[0].slipDays, 4);
 	assertEquals(driftFindings[0].overdue, false);
 });
@@ -143,12 +195,27 @@ Deno.test("flags drift-only via target-date slip", async () => {
 Deno.test("handles mixed findings and entropy threshold gate", async () => {
 	const files = createSnapshotFiles(
 		{
-			items: [{ id: "A", status: "in_progress", targetDate: "2026-03-01", scopePoints: 1 }],
+			items: [{
+				id: "A",
+				status: "in_progress",
+				targetDate: "2026-03-01",
+				scopePoints: 1,
+			}],
 		},
 		{
 			items: [
-				{ id: "A", status: "in_progress", targetDate: "2026-03-10", scopePoints: 3 },
-				{ id: "B", status: "blocked", targetDate: "2026-02-01", scopePoints: 2 },
+				{
+					id: "A",
+					status: "in_progress",
+					targetDate: "2026-03-10",
+					scopePoints: 3,
+				},
+				{
+					id: "B",
+					status: "blocked",
+					targetDate: "2026-02-01",
+					scopePoints: 2,
+				},
 			],
 		},
 	);
@@ -184,10 +251,20 @@ Deno.test("handles mixed findings and entropy threshold gate", async () => {
 Deno.test("supports threshold equality as healthy and stricter threshold as alert", async () => {
 	const files = createSnapshotFiles(
 		{
-			items: [{ id: "A", status: "in_progress", targetDate: "2026-06-01", scopePoints: 1 }],
+			items: [{
+				id: "A",
+				status: "in_progress",
+				targetDate: "2026-06-01",
+				scopePoints: 1,
+			}],
 		},
 		{
-			items: [{ id: "A", status: "in_progress", targetDate: "2026-06-01", scopePoints: 2 }],
+			items: [{
+				id: "A",
+				status: "in_progress",
+				targetDate: "2026-06-01",
+				scopePoints: 2,
+			}],
 		},
 	);
 
@@ -230,12 +307,27 @@ Deno.test("tracks removed items and respects scope threshold option", async () =
 	const files = createSnapshotFiles(
 		{
 			items: [
-				{ id: "A", status: "done", targetDate: "2026-01-01", scopePoints: 2 },
-				{ id: "B", status: "done", targetDate: "2026-01-01", scopePoints: 1 },
+				{
+					id: "A",
+					status: "done",
+					targetDate: "2026-01-01",
+					scopePoints: 2,
+				},
+				{
+					id: "B",
+					status: "done",
+					targetDate: "2026-01-01",
+					scopePoints: 1,
+				},
 			],
 		},
 		{
-			items: [{ id: "A", status: "done", targetDate: "2026-01-01", scopePoints: 3 }],
+			items: [{
+				id: "A",
+				status: "done",
+				targetDate: "2026-01-01",
+				scopePoints: 3,
+			}],
 		},
 	);
 
@@ -259,17 +351,30 @@ Deno.test("tracks removed items and respects scope threshold option", async () =
 
 	assertEquals(result.exitCode, 0);
 	const output = parseDetectorOutput(result.output);
-	assertEquals((output.metrics as Record<string, number>).removedItemCount, 1);
+	assertEquals(
+		(output.metrics as Record<string, number>).removedItemCount,
+		1,
+	);
 	assertEquals((output.metrics as Record<string, number>).creepCount, 0);
 });
 
 Deno.test("handles zero baseline and zero current scope without creep", async () => {
 	const files = createSnapshotFiles(
 		{
-			items: [{ id: "A", status: "done", targetDate: "2026-01-01", scopePoints: 0 }],
+			items: [{
+				id: "A",
+				status: "done",
+				targetDate: "2026-01-01",
+				scopePoints: 0,
+			}],
 		},
 		{
-			items: [{ id: "A", status: "done", targetDate: "2026-01-01", scopePoints: 0 }],
+			items: [{
+				id: "A",
+				status: "done",
+				targetDate: "2026-01-01",
+				scopePoints: 0,
+			}],
 		},
 	);
 
@@ -303,13 +408,19 @@ Deno.test("returns error for malformed schema", async () => {
 
 	assertEquals(result.exitCode, 1);
 	assert(result.error);
-	assertStringIncludes(result.error, "baseline snapshot items must be an array");
+	assertStringIncludes(
+		result.error,
+		"baseline snapshot items must be an array",
+	);
 });
 
 Deno.test("returns error when snapshot root is not an object", async () => {
 	const result = await runRoadmapEntropyDetectorCli(
 		["--baseline", "./baseline.json", "--current", "./current.json"],
-		createReadTextFile({ "./baseline.json": "[]", "./current.json": "{\"items\":[]}" }),
+		createReadTextFile({
+			"./baseline.json": "[]",
+			"./current.json": '{"items":[]}',
+		}),
 	);
 
 	assertEquals(result.exitCode, 1);
@@ -321,12 +432,27 @@ Deno.test("returns error for duplicate ids", async () => {
 	const files = createSnapshotFiles(
 		{
 			items: [
-				{ id: "A", status: "done", targetDate: "2026-01-01", scopePoints: 1 },
-				{ id: "A", status: "done", targetDate: "2026-01-01", scopePoints: 1 },
+				{
+					id: "A",
+					status: "done",
+					targetDate: "2026-01-01",
+					scopePoints: 1,
+				},
+				{
+					id: "A",
+					status: "done",
+					targetDate: "2026-01-01",
+					scopePoints: 1,
+				},
 			],
 		},
 		{
-			items: [{ id: "A", status: "done", targetDate: "2026-01-01", scopePoints: 1 }],
+			items: [{
+				id: "A",
+				status: "done",
+				targetDate: "2026-01-01",
+				scopePoints: 1,
+			}],
 		},
 	);
 
@@ -343,10 +469,19 @@ Deno.test("returns error for duplicate ids", async () => {
 Deno.test("returns error for missing id and invalid option values", async () => {
 	const files = createSnapshotFiles(
 		{
-			items: [{ id: "A", status: "done", targetDate: "2026-01-01", scopePoints: 1 }],
+			items: [{
+				id: "A",
+				status: "done",
+				targetDate: "2026-01-01",
+				scopePoints: 1,
+			}],
 		},
 		{
-			items: [{ status: "done", targetDate: "2026-01-01", scopePoints: 1 }],
+			items: [{
+				status: "done",
+				targetDate: "2026-01-01",
+				scopePoints: 1,
+			}],
 		},
 	);
 
@@ -359,7 +494,14 @@ Deno.test("returns error for missing id and invalid option values", async () => 
 	assertStringIncludes(missingIdResult.error, "non-empty id");
 
 	const invalidOptionResult = await runRoadmapEntropyDetectorCli(
-		["--baseline", "./baseline.json", "--current", "./current.json", "--max-drift-findings", "-1"],
+		[
+			"--baseline",
+			"./baseline.json",
+			"--current",
+			"./current.json",
+			"--max-drift-findings",
+			"-1",
+		],
 		createReadTextFile(files),
 	);
 	assertEquals(invalidOptionResult.exitCode, 1);
@@ -381,7 +523,12 @@ Deno.test("returns error for missing baseline option", async () => {
 Deno.test("returns error for missing scope and invalid tasks payload", async () => {
 	const filesMissingScope = createSnapshotFiles(
 		{
-			items: [{ id: "A", status: "done", targetDate: "2026-01-01", scopePoints: 1 }],
+			items: [{
+				id: "A",
+				status: "done",
+				targetDate: "2026-01-01",
+				scopePoints: 1,
+			}],
 		},
 		{
 			items: [{ id: "A", status: "done", targetDate: "2026-01-01" }],
@@ -398,10 +545,20 @@ Deno.test("returns error for missing scope and invalid tasks payload", async () 
 
 	const filesInvalidTasks = createSnapshotFiles(
 		{
-			items: [{ id: "A", status: "done", targetDate: "2026-01-01", tasks: ["x"] }],
+			items: [{
+				id: "A",
+				status: "done",
+				targetDate: "2026-01-01",
+				tasks: ["x"],
+			}],
 		},
 		{
-			items: [{ id: "A", status: "done", targetDate: "2026-01-01", tasks: ["x", 1] }],
+			items: [{
+				id: "A",
+				status: "done",
+				targetDate: "2026-01-01",
+				tasks: ["x", 1],
+			}],
 		},
 	);
 
@@ -411,7 +568,10 @@ Deno.test("returns error for missing scope and invalid tasks payload", async () 
 	);
 	assertEquals(invalidTasksResult.exitCode, 1);
 	assert(invalidTasksResult.error);
-	assertStringIncludes(invalidTasksResult.error, "tasks must contain only strings");
+	assertStringIncludes(
+		invalidTasksResult.error,
+		"tasks must contain only strings",
+	);
 });
 
 Deno.test("returns error for empty status, invalid targetDate type, and negative scopePoints", async () => {
@@ -419,7 +579,12 @@ Deno.test("returns error for empty status, invalid targetDate type, and negative
 		["--baseline", "./baseline.json", "--current", "./current.json"],
 		createReadTextFile({
 			"./baseline.json": JSON.stringify({
-				items: [{ id: "A", status: "", targetDate: "2026-01-01", scopePoints: 1 }],
+				items: [{
+					id: "A",
+					status: "",
+					targetDate: "2026-01-01",
+					scopePoints: 1,
+				}],
 			}),
 			"./current.json": JSON.stringify({ items: [] }),
 		}),
@@ -432,20 +597,33 @@ Deno.test("returns error for empty status, invalid targetDate type, and negative
 		["--baseline", "./baseline.json", "--current", "./current.json"],
 		createReadTextFile({
 			"./baseline.json": JSON.stringify({
-				items: [{ id: "A", status: "done", targetDate: 1, scopePoints: 1 }],
+				items: [{
+					id: "A",
+					status: "done",
+					targetDate: 1,
+					scopePoints: 1,
+				}],
 			}),
 			"./current.json": JSON.stringify({ items: [] }),
 		}),
 	);
 	assertEquals(invalidTargetDateTypeResult.exitCode, 1);
 	assert(invalidTargetDateTypeResult.error);
-	assertStringIncludes(invalidTargetDateTypeResult.error, "targetDate string");
+	assertStringIncludes(
+		invalidTargetDateTypeResult.error,
+		"targetDate string",
+	);
 
 	const negativeScopeResult = await runRoadmapEntropyDetectorCli(
 		["--baseline", "./baseline.json", "--current", "./current.json"],
 		createReadTextFile({
 			"./baseline.json": JSON.stringify({
-				items: [{ id: "A", status: "done", targetDate: "2026-01-01", scopePoints: -1 }],
+				items: [{
+					id: "A",
+					status: "done",
+					targetDate: "2026-01-01",
+					scopePoints: -1,
+				}],
 			}),
 			"./current.json": JSON.stringify({ items: [] }),
 		}),
@@ -458,10 +636,20 @@ Deno.test("returns error for empty status, invalid targetDate type, and negative
 Deno.test("returns error for invalid date strings and invalid json", async () => {
 	const filesInvalidDate = createSnapshotFiles(
 		{
-			items: [{ id: "A", status: "done", targetDate: "2026-13-01", scopePoints: 1 }],
+			items: [{
+				id: "A",
+				status: "done",
+				targetDate: "2026-13-01",
+				scopePoints: 1,
+			}],
 		},
 		{
-			items: [{ id: "A", status: "done", targetDate: "2026-01-01", scopePoints: 1 }],
+			items: [{
+				id: "A",
+				status: "done",
+				targetDate: "2026-01-01",
+				scopePoints: 1,
+			}],
 		},
 	);
 
@@ -486,7 +674,10 @@ Deno.test("returns error for invalid date strings and invalid json", async () =>
 	);
 	assertEquals(invalidTodayResult.exitCode, 1);
 	assert(invalidTodayResult.error);
-	assertStringIncludes(invalidTodayResult.error, "--today must use YYYY-MM-DD format");
+	assertStringIncludes(
+		invalidTodayResult.error,
+		"--today must use YYYY-MM-DD format",
+	);
 
 	const invalidJsonResult = await runRoadmapEntropyDetectorCli(
 		["--baseline", "./baseline.json", "--current", "./current.json"],
@@ -509,19 +700,26 @@ Deno.test("handles non-Error throws in catch path", async () => {
 });
 
 Deno.test("returns argument errors for unsupported and incomplete options", async () => {
-	const unsupportedResult = await runRoadmapEntropyDetectorCli(["--wat"], createReadTextFile({}));
+	const unsupportedResult = await runRoadmapEntropyDetectorCli(
+		["--wat"],
+		createReadTextFile({}),
+	);
 	assertEquals(unsupportedResult.exitCode, 1);
 	assert(unsupportedResult.error);
 	assertStringIncludes(unsupportedResult.error, "unsupported option");
 
-	const missingValueResult = await runRoadmapEntropyDetectorCli(["--baseline"], createReadTextFile({}));
+	const missingValueResult = await runRoadmapEntropyDetectorCli([
+		"--baseline",
+	], createReadTextFile({}));
 	assertEquals(missingValueResult.exitCode, 1);
 	assert(missingValueResult.error);
 	assertStringIncludes(missingValueResult.error, "requires a value");
 
 	const missingCurrentResult = await runRoadmapEntropyDetectorCli(
 		["--baseline", "./baseline.json"],
-		createReadTextFile({ "./baseline.json": JSON.stringify({ items: [] }) }),
+		createReadTextFile({
+			"./baseline.json": JSON.stringify({ items: [] }),
+		}),
 	);
 	assertEquals(missingCurrentResult.exitCode, 1);
 	assert(missingCurrentResult.error);


### PR DESCRIPTION
## Summary
- add a Deno CLI roadmap entropy detector at `bin/roadmap-entropy-detector.ts`
- compare baseline/current snapshots to flag scope creep and schedule drift
- add threshold-based exit behavior with machine-readable JSON output
- add docs and a focused detector test suite with 100/100/100 coverage

## Validation
- deno lint
- deno test --allow-read --coverage=coverage/roadmap-entropy tests/bin/roadmap-entropy-detector.test.ts
- deno coverage coverage/roadmap-entropy --include=bin/roadmap-entropy-detector.ts