### PR TITLE
feat: add test flakiness analyzer

### DIFF
--- a/bin/analyze-test-flakiness.ts
+++ b/bin/analyze-test-flakiness.ts
@@ -1,0 +1,622 @@
+#!/usr/bin/env -S deno run --allow-run --allow-read --allow-write
+
+const LINE_BREAK = "\n";
+const RUN_LOG_PREFIX = "run";
+const SUMMARY_TITLE = "Test Flakiness Analyzer";
+const SUMMARY_FLAKY_PREFIX = "-";
+const SUMMARY_NONE_MESSAGE = "No flaky tests detected.";
+const SUMMARY_REPORT_WRITE_PREFIX = "Wrote report:";
+const DEFAULT_OUTPUT_ENCODING = "utf-8";
+const SHELL_BINARY = "bash";
+const SHELL_EXECUTE_FLAG = "-lc";
+const TESTCASE_START_PATTERN = /<testcase\b([^>]*?)(\/?)>/g;
+const TESTCASE_CLOSE_TAG = "</testcase>";
+const XML_ATTRIBUTE_PATTERN = /([A-Za-z_][\w:.-]*)="([^"]*)"/g;
+const XML_ENTITY_PATTERN = /&([a-z]+);/g;
+const JUNIT_PATH_FLAG_PATTERN = /(?:^|\s)--junit-path(?:=|\s|$)/;
+const HELP_TEXT = [
+	"Usage: deno run --allow-run --allow-read --allow-write bin/analyze-test-flakiness.ts [options]",
+	"",
+	"Options:",
+	"  --runs, -r <count>        Number of test runs (default: 10)",
+	"  --command, -c <command>   Base test command (default: deno test --allow-read tests)",
+	"  --report, -o <path>       Output JSON report path (default: test-flakiness-report.json)",
+	"  --no-report               Skip writing the JSON report file",
+	"  --junit-dir <path>        Directory for per-run JUnit XML files (default: .tmp/test-flakiness)",
+	"  --help, -h                Show this help text",
+	"",
+	"Tip: Use {junitPath} in --command to place the generated JUnit file explicitly.",
+].join(LINE_BREAK);
+
+export const DEFAULT_RUN_COUNT = 10;
+export const DEFAULT_TEST_COMMAND = "deno test --allow-read tests";
+export const DEFAULT_REPORT_PATH = "test-flakiness-report.json";
+export const DEFAULT_JUNIT_DIRECTORY = ".tmp/test-flakiness";
+export const JUNIT_PATH_PLACEHOLDER = "{junitPath}";
+export const TESTCASE_IDENTIFIER_SEPARATOR = "::";
+export const UNNAMED_TEST_CASE_LABEL = "unnamed-testcase";
+
+export const EXIT_CODES = {
+	SUCCESS: 0,
+	ERROR: 1,
+	FLAKY_TESTS_FOUND: 2,
+} as const;
+
+export type TestStatus = "pass" | "fail" | "skipped";
+
+export interface AnalyzerOptions {
+	runs: number;
+	command: string;
+	reportPath: string | null;
+	junitDirectory: string;
+}
+
+export interface ParsedCliInput {
+	helpRequested: boolean;
+	options: AnalyzerOptions;
+}
+
+export interface CommandExecutionResult {
+	code: number;
+	stdout: string;
+	stderr: string;
+}
+
+export interface ParsedTestCase {
+	id: string;
+	name: string;
+	className: string;
+	status: TestStatus;
+}
+
+export interface RunReport {
+	runNumber: number;
+	command: string;
+	exitCode: number;
+	junitPath: string;
+	hadJUnitReport: boolean;
+	testCases: ParsedTestCase[];
+}
+
+export interface AggregatedTestCaseOutcome {
+	id: string;
+	name: string;
+	className: string;
+	passCount: number;
+	failCount: number;
+	skippedCount: number;
+	isFlaky: boolean;
+	statusesByRun: TestStatus[];
+}
+
+export interface FlakinessTotals {
+	totalRuns: number;
+	runsWithNonZeroExit: number;
+	runsWithoutJUnitReport: number;
+	testCaseCount: number;
+	flakyCount: number;
+}
+
+export interface FlakinessReport {
+	generatedAt: string;
+	options: AnalyzerOptions;
+	runs: RunReport[];
+	aggregatedTestCases: AggregatedTestCaseOutcome[];
+	flakyTests: AggregatedTestCaseOutcome[];
+	totals: FlakinessTotals;
+}
+
+export interface AnalyzerDependencies {
+	executeCommand(command: string): Promise<CommandExecutionResult>;
+	readTextFile(path: string): Promise<string | null>;
+	ensureDirectory(path: string): Promise<void>;
+	log(message: string): void;
+	now(): Date;
+}
+
+interface AggregateAccumulator {
+	id: string;
+	name: string;
+	className: string;
+	passCount: number;
+	failCount: number;
+	skippedCount: number;
+	statusesByRun: TestStatus[];
+}
+
+/**
+ * Parses command-line arguments into analyzer options.
+ *
+ * @param {string[]} args Command-line arguments.
+ * @returns {ParsedCliInput} Parsed CLI input.
+ */
+export function parseArgs(args: string[]): ParsedCliInput {
+	const options: AnalyzerOptions = {
+		runs: DEFAULT_RUN_COUNT,
+		command: DEFAULT_TEST_COMMAND,
+		reportPath: DEFAULT_REPORT_PATH,
+		junitDirectory: DEFAULT_JUNIT_DIRECTORY,
+	};
+	for (let index = 0; index < args.length; index += 1) {
+		const argument = args[index];
+		if (argument === "--help" || argument === "-h") {
+			return { helpRequested: true, options };
+		}
+		if (argument === "--runs" || argument === "-r") {
+			const value = readFlagValue(args, index, argument);
+			options.runs = parseRunsValue(value);
+			index += 1;
+			continue;
+		}
+		if (argument === "--command" || argument === "-c") {
+			const value = readFlagValue(args, index, argument);
+			options.command = value.trim();
+			if (options.command.length === 0) {
+				throw new Error("--command must not be empty");
+			}
+			index += 1;
+			continue;
+		}
+		if (argument === "--report" || argument === "-o") {
+			const value = readFlagValue(args, index, argument);
+			options.reportPath = value.trim();
+			if (options.reportPath.length === 0) {
+				throw new Error("--report must not be empty");
+			}
+			index += 1;
+			continue;
+		}
+		if (argument === "--junit-dir") {
+			const value = readFlagValue(args, index, argument);
+			options.junitDirectory = value.trim();
+			if (options.junitDirectory.length === 0) {
+				throw new Error("--junit-dir must not be empty");
+			}
+			index += 1;
+			continue;
+		}
+		if (argument === "--no-report") {
+			options.reportPath = null;
+			continue;
+		}
+		throw new Error(`Unknown argument: ${argument}`);
+	}
+	return { helpRequested: false, options };
+}
+
+/**
+ * Reads a value for a flag and validates that it exists.
+ *
+ * @param {string[]} args Full CLI argument list.
+ * @param {number} index Current argument index.
+ * @param {string} flagName Name of the flag being read.
+ * @returns {string} Flag value.
+ */
+export function readFlagValue(
+	args: string[],
+	index: number,
+	flagName: string,
+): string {
+	const value = args[index + 1];
+	if (value === undefined) {
+		throw new Error(`Missing value for ${flagName}`);
+	}
+	if (value.startsWith("-")) {
+		throw new Error(`Invalid value for ${flagName}: ${value}`);
+	}
+	return value;
+}
+
+/**
+ * Parses and validates the number of runs.
+ *
+ * @param {string} value CLI value to parse.
+ * @returns {number} Parsed run count.
+ */
+export function parseRunsValue(value: string): number {
+	const parsed = Number.parseInt(value, 10);
+	if (!Number.isInteger(parsed) || parsed < 2) {
+		throw new Error("--runs must be an integer greater than or equal to 2");
+	}
+	return parsed;
+}
+
+/**
+ * Escapes a shell argument for safe execution in `bash -lc`.
+ *
+ * @param {string} value Raw argument value.
+ * @returns {string} Shell-escaped argument.
+ */
+export function quoteShellArgument(value: string): string {
+	return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+/**
+ * Builds the per-run command including the JUnit output path.
+ *
+ * @param {string} baseCommand Base test command.
+ * @param {string} junitPath JUnit report path for this run.
+ * @returns {string} Command ready to execute.
+ */
+export function buildRunCommand(baseCommand: string, junitPath: string): string {
+	if (baseCommand.includes(JUNIT_PATH_PLACEHOLDER)) {
+		return baseCommand.replaceAll(
+			JUNIT_PATH_PLACEHOLDER,
+			quoteShellArgument(junitPath),
+		);
+	}
+	if (JUNIT_PATH_FLAG_PATTERN.test(baseCommand)) {
+		return baseCommand;
+	}
+	return `${baseCommand} --junit-path ${quoteShellArgument(junitPath)}`;
+}
+
+/**
+ * Decodes supported XML entities from attribute or text values.
+ *
+ * @param {string} value Raw XML value.
+ * @returns {string} Decoded value.
+ */
+export function decodeXmlEntities(value: string): string {
+	return value.replaceAll(XML_ENTITY_PATTERN, (entity, namedEntity) => {
+		if (namedEntity === "amp") {
+			return "&";
+		}
+		if (namedEntity === "lt") {
+			return "<";
+		}
+		if (namedEntity === "gt") {
+			return ">";
+		}
+		if (namedEntity === "quot") {
+			return '"';
+		}
+		if (namedEntity === "apos") {
+			return "'";
+		}
+		return entity;
+	});
+}
+
+/**
+ * Parses XML attributes from a testcase element.
+ *
+ * @param {string} attributesText Raw attribute text.
+ * @returns {Record<string, string>} Parsed attributes.
+ */
+export function parseXmlAttributes(attributesText: string): Record<string, string> {
+	const attributes: Record<string, string> = {};
+	for (const match of attributesText.matchAll(XML_ATTRIBUTE_PATTERN)) {
+		const attributeName = match[1];
+		const attributeValue = match[2];
+		attributes[attributeName] = decodeXmlEntities(attributeValue);
+	}
+	return attributes;
+}
+
+/**
+ * Creates a stable testcase identifier from classname and testcase name.
+ *
+ * @param {string} className Testcase class name.
+ * @param {string} name Testcase name.
+ * @returns {string} Stable testcase identifier.
+ */
+export function createTestCaseId(className: string, name: string): string {
+	const trimmedClassName = className.trim();
+	if (trimmedClassName.length === 0) {
+		return name;
+	}
+	return `${trimmedClassName}${TESTCASE_IDENTIFIER_SEPARATOR}${name}`;
+}
+
+/**
+ * Determines testcase status from testcase element contents.
+ *
+ * @param {string} testcaseBody Inner testcase XML.
+ * @returns {TestStatus} Derived testcase status.
+ */
+export function determineTestStatus(testcaseBody: string): TestStatus {
+	if (testcaseBody.includes("<failure") || testcaseBody.includes("<error")) {
+		return "fail";
+	}
+	if (testcaseBody.includes("<skipped")) {
+		return "skipped";
+	}
+	return "pass";
+}
+
+/**
+ * Parses JUnit XML and extracts testcase statuses.
+ *
+ * @param {string} junitXml JUnit XML content.
+ * @returns {ParsedTestCase[]} Parsed testcase results.
+ */
+export function parseJUnitTestCases(junitXml: string): ParsedTestCase[] {
+	const testCases: ParsedTestCase[] = [];
+	TESTCASE_START_PATTERN.lastIndex = 0;
+	let testcaseStartMatch = TESTCASE_START_PATTERN.exec(junitXml);
+	while (testcaseStartMatch !== null) {
+		const attributesText = testcaseStartMatch[1];
+		const isSelfClosing = testcaseStartMatch[2] === "/";
+		const bodyStartIndex = testcaseStartMatch.index +
+			testcaseStartMatch[0].length;
+		let testcaseBody = "";
+		if (!isSelfClosing) {
+			const bodyEndIndex = junitXml.indexOf(TESTCASE_CLOSE_TAG, bodyStartIndex);
+			if (bodyEndIndex === -1) {
+				testcaseBody = junitXml.slice(bodyStartIndex);
+			} else {
+				testcaseBody = junitXml.slice(bodyStartIndex, bodyEndIndex);
+				TESTCASE_START_PATTERN.lastIndex = bodyEndIndex +
+					TESTCASE_CLOSE_TAG.length;
+			}
+		}
+		const attributes = parseXmlAttributes(attributesText);
+		const name = (attributes.name?.trim() || UNNAMED_TEST_CASE_LABEL);
+		const className = (attributes.classname?.trim() || "");
+		testCases.push({
+			id: createTestCaseId(className, name),
+			name,
+			className,
+			status: determineTestStatus(testcaseBody),
+		});
+		testcaseStartMatch = TESTCASE_START_PATTERN.exec(junitXml);
+	}
+	return testCases;
+}
+
+/**
+ * Aggregates testcase results across runs and marks flaky tests.
+ *
+ * @param {RunReport[]} runs Per-run test results.
+ * @returns {AggregatedTestCaseOutcome[]} Aggregated testcase outcomes.
+ */
+export function aggregateTestCaseOutcomes(
+	runs: RunReport[],
+): AggregatedTestCaseOutcome[] {
+	const accumulatorMap = new Map<string, AggregateAccumulator>();
+	for (const run of runs) {
+		for (const testCase of run.testCases) {
+			const existing = accumulatorMap.get(testCase.id) ?? {
+				id: testCase.id,
+				name: testCase.name,
+				className: testCase.className,
+				passCount: 0,
+				failCount: 0,
+				skippedCount: 0,
+				statusesByRun: [],
+			};
+			if (testCase.status === "pass") {
+				existing.passCount += 1;
+			}
+			if (testCase.status === "fail") {
+				existing.failCount += 1;
+			}
+			if (testCase.status === "skipped") {
+				existing.skippedCount += 1;
+			}
+			existing.statusesByRun.push(testCase.status);
+			accumulatorMap.set(testCase.id, existing);
+		}
+	}
+	return [...accumulatorMap.values()].map((entry) => ({
+		...entry,
+		isFlaky: entry.passCount > 0 && entry.failCount > 0,
+	})).toSorted((left, right) => left.id.localeCompare(right.id));
+}
+
+/**
+ * Computes report totals from runs and aggregated testcase outcomes.
+ *
+ * @param {RunReport[]} runs Per-run test results.
+ * @param {AggregatedTestCaseOutcome[]} aggregatedTestCases Aggregated testcase outcomes.
+ * @returns {FlakinessTotals} Summary totals.
+ */
+export function calculateTotals(
+	runs: RunReport[],
+	aggregatedTestCases: AggregatedTestCaseOutcome[],
+): FlakinessTotals {
+	const runsWithNonZeroExit = runs.filter((run) => run.exitCode !== 0).length;
+	const runsWithoutJUnitReport = runs.filter((run) => !run.hadJUnitReport).length;
+	const flakyCount = aggregatedTestCases.filter((testCase) => testCase.isFlaky).length;
+	return {
+		totalRuns: runs.length,
+		runsWithNonZeroExit,
+		runsWithoutJUnitReport,
+		testCaseCount: aggregatedTestCases.length,
+		flakyCount,
+	};
+}
+
+/**
+ * Selects an analyzer exit code based on report outcomes.
+ *
+ * @param {FlakinessReport} report Analyzer report.
+ * @returns {number} Exit code.
+ */
+export function calculateExitCode(report: FlakinessReport): number {
+	if (report.totals.flakyCount > 0) {
+		return EXIT_CODES.FLAKY_TESTS_FOUND;
+	}
+	if (report.totals.runsWithoutJUnitReport > 0) {
+		return EXIT_CODES.ERROR;
+	}
+	return EXIT_CODES.SUCCESS;
+}
+
+/**
+ * Renders a human-readable summary of the flakiness report.
+ *
+ * @param {FlakinessReport} report Analyzer report.
+ * @returns {string} Text summary.
+ */
+export function renderSummary(report: FlakinessReport): string {
+	const lines = [
+		SUMMARY_TITLE,
+		`Runs: ${report.totals.totalRuns}`,
+		`Command: ${report.options.command}`,
+		`Observed testcases: ${report.totals.testCaseCount}`,
+		`Flaky tests: ${report.totals.flakyCount}`,
+	];
+	if (report.totals.flakyCount === 0) {
+		lines.push(SUMMARY_NONE_MESSAGE);
+	} else {
+		for (const testCase of report.flakyTests) {
+			lines.push(
+			`${SUMMARY_FLAKY_PREFIX} ${testCase.id} (pass: ${testCase.passCount}, fail: ${testCase.failCount}, skipped: ${testCase.skippedCount})`,
+			);
+		}
+	}
+	if (report.totals.runsWithoutJUnitReport > 0) {
+		lines.push(`Runs without JUnit report: ${report.totals.runsWithoutJUnitReport}`);
+	}
+	if (report.totals.runsWithNonZeroExit > 0) {
+		lines.push(`Runs with non-zero exit: ${report.totals.runsWithNonZeroExit}`);
+	}
+	return lines.join(LINE_BREAK);
+}
+
+/**
+ * Writes the report file to disk.
+ *
+ * @param {string} reportPath Destination report path.
+ * @param {FlakinessReport} report Analyzer report.
+ * @returns {Promise<void>}
+ */
+export async function writeReport(
+	reportPath: string,
+	report: FlakinessReport,
+): Promise<void> {
+	await Deno.writeTextFile(reportPath, `${JSON.stringify(report, null, 2)}${LINE_BREAK}`);
+}
+
+/**
+ * Runs the analyzer for all iterations and returns the full report.
+ *
+ * @param {AnalyzerOptions} options Analyzer execution options.
+ * @param {AnalyzerDependencies} dependencies Runtime dependencies.
+ * @returns {Promise<FlakinessReport>} Analyzer report.
+ */
+export async function analyzeFlakiness(
+	options: AnalyzerOptions,
+	dependencies: AnalyzerDependencies,
+): Promise<FlakinessReport> {
+	await dependencies.ensureDirectory(options.junitDirectory);
+	const runs: RunReport[] = [];
+	for (let runNumber = 1; runNumber <= options.runs; runNumber += 1) {
+		const junitPath = `${options.junitDirectory}/run-${runNumber}.xml`;
+		const command = buildRunCommand(options.command, junitPath);
+		const commandResult = await dependencies.executeCommand(command);
+		const junitXml = await dependencies.readTextFile(junitPath);
+		const hadJUnitReport = junitXml !== null;
+		const testCases = junitXml === null ? [] : parseJUnitTestCases(junitXml);
+		dependencies.log(
+			`[${RUN_LOG_PREFIX} ${runNumber}/${options.runs}] exit=${commandResult.code} testcases=${testCases.length}`,
+		);
+		runs.push({
+			runNumber,
+			command,
+			exitCode: commandResult.code,
+			junitPath,
+			hadJUnitReport,
+			testCases,
+		});
+	}
+	const aggregatedTestCases = aggregateTestCaseOutcomes(runs);
+	const flakyTests = aggregatedTestCases.filter((testCase) => testCase.isFlaky);
+	const totals = calculateTotals(runs, aggregatedTestCases);
+	return {
+		generatedAt: dependencies.now().toISOString(),
+		options,
+		runs,
+		aggregatedTestCases,
+		flakyTests,
+		totals,
+	};
+}
+
+/**
+ * Creates runtime dependencies backed by the Deno APIs.
+ *
+ * @returns {AnalyzerDependencies} Runtime dependencies.
+ */
+export function createDenoDependencies(): AnalyzerDependencies {
+	const decoder = new TextDecoder(DEFAULT_OUTPUT_ENCODING);
+	return {
+		async executeCommand(command: string): Promise<CommandExecutionResult> {
+			const output = await new Deno.Command(SHELL_BINARY, {
+				args: [SHELL_EXECUTE_FLAG, command],
+				stdout: "piped",
+				stderr: "piped",
+			}).output();
+			return {
+				code: output.code,
+				stdout: decoder.decode(output.stdout),
+				stderr: decoder.decode(output.stderr),
+			};
+		},
+		async readTextFile(path: string): Promise<string | null> {
+			try {
+				return await Deno.readTextFile(path);
+			} catch (error) {
+				if (error instanceof Deno.errors.NotFound) {
+					return null;
+				}
+				throw error;
+			}
+		},
+		async ensureDirectory(path: string): Promise<void> {
+			await Deno.mkdir(path, { recursive: true });
+		},
+		log(message: string): void {
+			console.log(message);
+		},
+		now(): Date {
+			return new Date();
+		},
+	};
+}
+
+/**
+ * Prints CLI help text.
+ *
+ * @returns {void}
+ */
+export function printHelp(): void {
+	console.log(HELP_TEXT);
+}
+
+/**
+ * Executes the CLI entrypoint.
+ *
+ * @returns {Promise<void>}
+ */
+export async function runCli(): Promise<void> {
+	let parsedInput: ParsedCliInput;
+	try {
+		parsedInput = parseArgs(Deno.args);
+	} catch (error) {
+		const message = (error as Error).message;
+		console.error(message);
+		printHelp();
+		Deno.exit(EXIT_CODES.ERROR);
+	}
+	if (parsedInput.helpRequested) {
+		printHelp();
+		Deno.exit(EXIT_CODES.SUCCESS);
+	}
+	const dependencies = createDenoDependencies();
+	const report = await analyzeFlakiness(parsedInput.options, dependencies);
+	dependencies.log(renderSummary(report));
+	if (parsedInput.options.reportPath !== null) {
+		await writeReport(parsedInput.options.reportPath, report);
+		dependencies.log(`${SUMMARY_REPORT_WRITE_PREFIX} ${parsedInput.options.reportPath}`);
+	}
+	Deno.exit(calculateExitCode(report));
+}
+
+// deno-coverage-ignore-start
+if (import.meta.main) {
+	await runCli();
+}
+// deno-coverage-ignore-stop

--- a/deno.json
+++ b/deno.json
@@ -22,6 +22,7 @@
 		"test-bg": "deno test --allow-read --coverage --parallel --quiet tests/background/",
 		"test-cmp": "deno test --allow-read --coverage --parallel --quiet tests/components/",
 		"test-sf": "deno test --allow-read --coverage --parallel --quiet tests/salesforce/*.test.ts",
+		"test-flakiness": "deno run --allow-run --allow-read --allow-write bin/analyze-test-flakiness.ts",
 
 		"fmt": "deno fmt",
 		"lint": "deno lint",

--- a/tests/bin/analyze-test-flakiness.test.ts
+++ b/tests/bin/analyze-test-flakiness.test.ts
@@ -1,0 +1,537 @@
+import {
+	assert,
+	assertEquals,
+	assertRejects,
+	assertStringIncludes,
+	assertThrows,
+} from "@std/testing/asserts";
+import { stub } from "@std/testing/mock";
+import {
+	aggregateTestCaseOutcomes,
+	analyzeFlakiness,
+	buildRunCommand,
+	calculateExitCode,
+	calculateTotals,
+	createDenoDependencies,
+	createTestCaseId,
+	decodeXmlEntities,
+	DEFAULT_JUNIT_DIRECTORY,
+	DEFAULT_REPORT_PATH,
+	DEFAULT_RUN_COUNT,
+	DEFAULT_TEST_COMMAND,
+	determineTestStatus,
+	EXIT_CODES,
+	JUNIT_PATH_PLACEHOLDER,
+	parseArgs,
+	parseJUnitTestCases,
+	parseRunsValue,
+	parseXmlAttributes,
+	quoteShellArgument,
+	renderSummary,
+	runCli,
+	UNNAMED_TEST_CASE_LABEL,
+	writeReport,
+	type AggregatedTestCaseOutcome,
+	type AnalyzerDependencies,
+	type AnalyzerOptions,
+	type FlakinessReport,
+	type RunReport,
+} from "../../bin/analyze-test-flakiness.ts";
+
+const XML_PASS_FAIL_SKIP = `<testsuite>
+	<testcase classname="suite.alpha" name="passes" />
+	<testcase classname="suite.alpha" name="fails"><failure message="boom" /></testcase>
+	<testcase classname="suite.alpha" name="skips"><skipped /></testcase>
+	<testcase name="entity &amp; &quot;quoted&quot;"><error /></testcase>
+	<testcase classname="suite.alpha"></testcase>
+</testsuite>`;
+
+const XML_ALL_PASS = `<testsuite>
+	<testcase classname="suite.alpha" name="passes" />
+</testsuite>`;
+
+const XML_FAIL_ONLY = `<testsuite>
+	<testcase classname="suite.alpha" name="passes"><failure message="boom" /></testcase>
+</testsuite>`;
+
+/**
+ * Creates a run report object for summary and exit-code tests.
+ *
+ * @param {RunReport[]} runs Per-run reports.
+ * @param {AggregatedTestCaseOutcome[]} aggregated Aggregated testcase outcomes.
+ * @returns {FlakinessReport} Flakiness report.
+ */
+function createReport(
+	runs: RunReport[],
+	aggregated: AggregatedTestCaseOutcome[],
+): FlakinessReport {
+	const totals = calculateTotals(runs, aggregated);
+	const flakyTests = aggregated.filter((entry) => entry.isFlaky);
+	return {
+		generatedAt: "2026-04-01T00:00:00.000Z",
+		options: {
+			runs: runs.length,
+			command: DEFAULT_TEST_COMMAND,
+			reportPath: DEFAULT_REPORT_PATH,
+			junitDirectory: DEFAULT_JUNIT_DIRECTORY,
+		},
+		runs,
+		aggregatedTestCases: aggregated,
+		flakyTests,
+		totals,
+	};
+}
+
+/**
+ * Reads a report file and parses it as JSON.
+ *
+ * @param {string} reportPath Report file path.
+ * @returns {Promise<FlakinessReport>} Parsed report payload.
+ */
+async function readReport(reportPath: string): Promise<FlakinessReport> {
+	return JSON.parse(await Deno.readTextFile(reportPath));
+}
+
+/**
+ * Overrides `Deno.args` for a test and returns a restore callback.
+ *
+ * @param {string[]} args Replacement CLI arguments.
+ * @returns {() => void} Callback that restores the original descriptor.
+ */
+function overrideDenoArgs(args: string[]): () => void {
+	const descriptor = Object.getOwnPropertyDescriptor(Deno, "args");
+	Object.defineProperty(Deno, "args", {
+		value: args,
+		configurable: true,
+	});
+	return function restoreArgs(): void {
+		if (descriptor !== undefined) {
+			Object.defineProperty(Deno, "args", descriptor);
+		}
+	};
+}
+
+Deno.test("parseArgs returns defaults and supports no-report", () => {
+	const defaults = parseArgs([]);
+	assertEquals(defaults.helpRequested, false);
+	assertEquals(defaults.options, {
+		runs: DEFAULT_RUN_COUNT,
+		command: DEFAULT_TEST_COMMAND,
+		reportPath: DEFAULT_REPORT_PATH,
+		junitDirectory: DEFAULT_JUNIT_DIRECTORY,
+	});
+
+	const noReport = parseArgs(["--no-report"]);
+	assertEquals(noReport.options.reportPath, null);
+});
+
+Deno.test("parseArgs parses explicit values and help", () => {
+	const parsed = parseArgs([
+		"--runs",
+		"5",
+		"--command",
+		"deno test --allow-read tests --junit-path {junitPath}",
+		"--report",
+		"tmp/report.json",
+		"--junit-dir",
+		"tmp/reports",
+	]);
+	assertEquals(parsed.helpRequested, false);
+	assertEquals(parsed.options.runs, 5);
+	assertEquals(parsed.options.command, "deno test --allow-read tests --junit-path {junitPath}");
+	assertEquals(parsed.options.reportPath, "tmp/report.json");
+	assertEquals(parsed.options.junitDirectory, "tmp/reports");
+
+	const help = parseArgs(["-h"]);
+	assertEquals(help.helpRequested, true);
+});
+
+Deno.test("parseArgs validates invalid flags and runs", () => {
+	assertThrows(() => parseArgs(["--unknown"]), Error, "Unknown argument");
+	assertThrows(() => parseArgs(["--runs"]), Error, "Missing value");
+	assertThrows(() => parseArgs(["--runs", "-1"]), Error, "Invalid value");
+	assertThrows(() => parseArgs(["--command", "  "]), Error, "must not be empty");
+	assertThrows(() => parseArgs(["--report", "   "]), Error, "must not be empty");
+	assertThrows(() => parseArgs(["--junit-dir", "  "]), Error, "must not be empty");
+	assertThrows(() => parseRunsValue("1"), Error, "greater than or equal to 2");
+	assertThrows(() => parseRunsValue("abc"), Error, "greater than or equal to 2");
+});
+
+Deno.test("buildRunCommand appends, preserves, and replaces junit path", () => {
+	const appended = buildRunCommand("deno test --allow-read tests", "tmp/report 1.xml");
+	assertStringIncludes(appended, "--junit-path");
+	assertStringIncludes(appended, "'tmp/report 1.xml'");
+
+	const withPlaceholder = buildRunCommand(
+		`deno test --allow-read tests --junit-path ${JUNIT_PATH_PLACEHOLDER}`,
+		"tmp/report.xml",
+	);
+	assertStringIncludes(withPlaceholder, "--junit-path 'tmp/report.xml'");
+
+	const preserved = buildRunCommand(
+		"deno test --allow-read tests --junit-path existing.xml",
+		"tmp/ignored.xml",
+	);
+	assertEquals(
+		preserved,
+		"deno test --allow-read tests --junit-path existing.xml",
+	);
+});
+
+Deno.test("quoteShellArgument escapes single quote values", () => {
+	assertEquals(quoteShellArgument("plain"), "'plain'");
+	assertEquals(quoteShellArgument("a'b"), "'a'\"'\"'b'");
+});
+
+Deno.test("decodeXmlEntities and parseXmlAttributes decode xml entities", () => {
+	assertEquals(decodeXmlEntities("a&amp;b&lt;c&gt;d&quot;e&apos;f&noop;"), "a&b<c>d\"e'f&noop;");
+	assertEquals(
+		parseXmlAttributes('name="alpha &amp; beta" classname="suite&quot;one"'),
+		{ name: "alpha & beta", classname: 'suite"one' },
+	);
+});
+
+Deno.test("parseJUnitTestCases extracts pass, fail, skip, error, and unnamed tests", () => {
+	const parsed = parseJUnitTestCases(XML_PASS_FAIL_SKIP);
+	assertEquals(parsed.length, 5);
+	assertEquals(parsed[0], {
+		id: "suite.alpha::passes",
+		name: "passes",
+		className: "suite.alpha",
+		status: "pass",
+	});
+	assertEquals(parsed[1].status, "fail");
+	assertEquals(parsed[2].status, "skipped");
+	assertEquals(parsed[3], {
+		id: 'entity & "quoted"',
+		name: 'entity & "quoted"',
+		className: "",
+		status: "fail",
+	});
+	assertEquals(parsed[4].name, UNNAMED_TEST_CASE_LABEL);
+	assertEquals(parsed[4].status, "pass");
+});
+
+Deno.test("parseJUnitTestCases tolerates missing testcase close tag", () => {
+	const parsed = parseJUnitTestCases("<testsuite><testcase classname=\"suite\" name=\"broken\">");
+	assertEquals(parsed.length, 1);
+	assertEquals(parsed[0], {
+		id: "suite::broken",
+		name: "broken",
+		className: "suite",
+		status: "pass",
+	});
+});
+
+Deno.test("determineTestStatus and createTestCaseId handle edge cases", () => {
+	assertEquals(determineTestStatus("<system-out>ok</system-out>"), "pass");
+	assertEquals(determineTestStatus("<failure />"), "fail");
+	assertEquals(determineTestStatus("<error />"), "fail");
+	assertEquals(determineTestStatus("<skipped />"), "skipped");
+	assertEquals(createTestCaseId("suite", "case"), "suite::case");
+	assertEquals(createTestCaseId("", "case"), "case");
+});
+
+Deno.test("aggregateTestCaseOutcomes counts skipped tests", () => {
+	const aggregated = aggregateTestCaseOutcomes([
+		{
+			runNumber: 1,
+			command: "deno test",
+			exitCode: 0,
+			junitPath: "run-1.xml",
+			hadJUnitReport: true,
+			testCases: [
+				{
+					id: "suite::skip-me",
+					name: "skip-me",
+					className: "suite",
+					status: "skipped",
+				},
+			],
+		},
+	]);
+	assertEquals(aggregated.length, 1);
+	assertEquals(aggregated[0].skippedCount, 1);
+	assertEquals(aggregated[0].isFlaky, false);
+});
+
+Deno.test("analyzeFlakiness aggregates flaky testcase and missing junit runs", async () => {
+	const logs: string[] = [];
+	const executedCommands: string[] = [];
+	let ensureDirectoryCalls = 0;
+	const options: AnalyzerOptions = {
+		runs: 3,
+		command: "deno test --allow-read tests",
+		reportPath: null,
+		junitDirectory: "tmp/junit",
+	};
+	const dependencies: AnalyzerDependencies = {
+		executeCommand(command: string) {
+			executedCommands.push(command);
+			return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+		},
+		readTextFile(path: string) {
+			if (path.endsWith("run-1.xml")) {
+				return Promise.resolve(XML_ALL_PASS);
+			}
+			if (path.endsWith("run-2.xml")) {
+				return Promise.resolve(XML_FAIL_ONLY);
+			}
+			return Promise.resolve(null);
+		},
+		ensureDirectory() {
+			ensureDirectoryCalls += 1;
+			return Promise.resolve();
+		},
+		log(message: string) {
+			logs.push(message);
+		},
+		now() {
+			return new Date("2026-04-01T10:00:00.000Z");
+		},
+	};
+
+	const report = await analyzeFlakiness(options, dependencies);
+	assertEquals(ensureDirectoryCalls, 1);
+	assertEquals(executedCommands.length, 3);
+	assertEquals(logs.length, 3);
+	assertEquals(report.generatedAt, "2026-04-01T10:00:00.000Z");
+	assertEquals(report.totals, {
+		totalRuns: 3,
+		runsWithNonZeroExit: 0,
+		runsWithoutJUnitReport: 1,
+		testCaseCount: 1,
+		flakyCount: 1,
+	});
+	assertEquals(report.flakyTests.length, 1);
+	assertEquals(report.flakyTests[0].id, "suite.alpha::passes");
+	assertEquals(report.flakyTests[0].passCount, 1);
+	assertEquals(report.flakyTests[0].failCount, 1);
+});
+
+Deno.test("renderSummary and calculateExitCode reflect report states", () => {
+	const flakyReport = createReport(
+		[
+			{
+				runNumber: 1,
+				command: "deno test",
+				exitCode: 0,
+				junitPath: "run-1.xml",
+				hadJUnitReport: true,
+				testCases: [
+					{ id: "suite::case", name: "case", className: "suite", status: "pass" },
+				],
+			},
+			{
+				runNumber: 2,
+				command: "deno test",
+				exitCode: 1,
+				junitPath: "run-2.xml",
+				hadJUnitReport: true,
+				testCases: [
+					{ id: "suite::case", name: "case", className: "suite", status: "fail" },
+				],
+			},
+		],
+		[
+			{
+				id: "suite::case",
+				name: "case",
+				className: "suite",
+				passCount: 1,
+				failCount: 1,
+				skippedCount: 0,
+				isFlaky: true,
+				statusesByRun: ["pass", "fail"],
+			},
+		],
+	);
+	const flakySummary = renderSummary(flakyReport);
+	assertStringIncludes(flakySummary, "Flaky tests: 1");
+	assertStringIncludes(flakySummary, "- suite::case (pass: 1, fail: 1, skipped: 0)");
+	assertStringIncludes(flakySummary, "Runs with non-zero exit: 1");
+	assertEquals(calculateExitCode(flakyReport), EXIT_CODES.FLAKY_TESTS_FOUND);
+
+	const errorReport = createReport(
+		[
+			{
+				runNumber: 1,
+				command: "deno test",
+				exitCode: 0,
+				junitPath: "run-1.xml",
+				hadJUnitReport: false,
+				testCases: [],
+			},
+		],
+		[],
+	);
+	assertStringIncludes(renderSummary(errorReport), "Runs without JUnit report: 1");
+	assertEquals(calculateExitCode(errorReport), EXIT_CODES.ERROR);
+
+	const successReport = createReport(
+		[
+			{
+				runNumber: 1,
+				command: "deno test",
+				exitCode: 0,
+				junitPath: "run-1.xml",
+				hadJUnitReport: true,
+				testCases: [
+					{ id: "suite::stable", name: "stable", className: "suite", status: "pass" },
+				],
+			},
+		],
+		[
+			{
+				id: "suite::stable",
+				name: "stable",
+				className: "suite",
+				passCount: 1,
+				failCount: 0,
+				skippedCount: 0,
+				isFlaky: false,
+				statusesByRun: ["pass"],
+			},
+		],
+	);
+	assertStringIncludes(renderSummary(successReport), "No flaky tests detected.");
+	assertEquals(calculateExitCode(successReport), EXIT_CODES.SUCCESS);
+});
+
+Deno.test("writeReport writes JSON payload", async () => {
+	const tempDir = await Deno.makeTempDir();
+	const reportPath = `${tempDir}/flaky-report.json`;
+	const report = createReport([], []);
+	try {
+		await writeReport(reportPath, report);
+		const parsed = await readReport(reportPath);
+		assertEquals(parsed.generatedAt, report.generatedAt);
+		assertEquals(parsed.totals.flakyCount, 0);
+	} finally {
+		await Deno.remove(tempDir, { recursive: true });
+	}
+});
+
+Deno.test("createDenoDependencies ensures directories, reads missing files, and executes commands", async () => {
+	const dependencies = createDenoDependencies();
+	const tempDir = await Deno.makeTempDir();
+	const missingFilePath = `${tempDir}/missing.xml`;
+	const nestedDirPath = `${tempDir}/nested/dir`;
+	try {
+		await dependencies.ensureDirectory(nestedDirPath);
+		const stats = await Deno.stat(nestedDirPath);
+		assert(stats.isDirectory);
+
+		const missingRead = await dependencies.readTextFile(missingFilePath);
+		assertEquals(missingRead, null);
+
+		const commandResult = await dependencies.executeCommand("printf hello");
+		assertEquals(commandResult.code, 0);
+		assertEquals(commandResult.stdout, "hello");
+		assertEquals(commandResult.stderr, "");
+	} finally {
+		await Deno.remove(tempDir, { recursive: true });
+	}
+});
+
+Deno.test("createDenoDependencies rethrows non-NotFound read errors", async () => {
+	const dependencies = createDenoDependencies();
+	const readTextFileStub = stub(
+		Deno,
+		"readTextFile",
+		() => Promise.reject(new Error("boom")),
+	);
+	try {
+		await assertRejects(
+			() => dependencies.readTextFile("ignored-path"),
+			Error,
+			"boom",
+		);
+	} finally {
+		readTextFileStub.restore();
+	}
+});
+
+Deno.test("runCli exits with success on help", async () => {
+	const exits: number[] = [];
+	const restoreArgs = overrideDenoArgs(["--help"]);
+	const exitStub = stub(Deno, "exit", (code?: number): never => {
+		exits.push(code ?? 0);
+		throw new Error(`exit:${code ?? 0}`);
+	});
+	try {
+		await assertRejects(() => runCli(), Error, "exit:0");
+		assertEquals(exits, [0]);
+	} finally {
+		exitStub.restore();
+		restoreArgs();
+	}
+});
+
+Deno.test("runCli exits with error on invalid args", async () => {
+	const exits: number[] = [];
+	const restoreArgs = overrideDenoArgs(["--runs", "abc"]);
+	const exitStub = stub(Deno, "exit", (code?: number): never => {
+		exits.push(code ?? 0);
+		throw new Error(`exit:${code ?? 0}`);
+	});
+	try {
+		await assertRejects(() => runCli(), Error, "exit:1");
+		assertEquals(exits, [1]);
+	} finally {
+		exitStub.restore();
+		restoreArgs();
+	}
+});
+
+Deno.test("runCli runs analyzer and writes report before exiting", async () => {
+	const exits: number[] = [];
+	const tempDir = await Deno.makeTempDir();
+	const reportPath = `${tempDir}/cli-report.json`;
+	const junitDir = `${tempDir}/junit`;
+	const restoreArgs = overrideDenoArgs([
+		"--runs",
+		"2",
+		"--command",
+		"printf done",
+		"--junit-dir",
+		junitDir,
+		"--report",
+		reportPath,
+	]);
+	const exitStub = stub(Deno, "exit", (code?: number): never => {
+		exits.push(code ?? 0);
+		throw new Error(`exit:${code ?? 0}`);
+	});
+	try {
+		await assertRejects(() => runCli(), Error, "exit:1");
+		const report = await readReport(reportPath);
+		assertEquals(report.totals.totalRuns, 2);
+		assertEquals(report.totals.runsWithoutJUnitReport, 2);
+		assertEquals(report.totals.flakyCount, 0);
+		assertEquals(exits, [1]);
+	} finally {
+		exitStub.restore();
+		restoreArgs();
+		await Deno.remove(tempDir, { recursive: true });
+	}
+});
+
+Deno.test("entrypoint executes with --help", async () => {
+	const output = await new Deno.Command("deno", {
+		args: [
+			"run",
+			"--allow-run",
+			"--allow-read",
+			"--allow-write",
+			"bin/analyze-test-flakiness.ts",
+			"--help",
+		],
+		stdout: "piped",
+		stderr: "piped",
+	}).output();
+	const decoder = new TextDecoder();
+	assertEquals(output.code, 0);
+	assertStringIncludes(decoder.decode(output.stdout), "Usage:");
+	assertEquals(decoder.decode(output.stderr), "");
+});


### PR DESCRIPTION
## Summary
- add a dependency-free Deno CLI analyzer at `bin/analyze-test-flakiness.ts` that reruns tests, parses per-testcase JUnit outcomes, and flags pass/fail instability
- add a `test-flakiness` task in `deno.json` with `--allow-run --allow-read --allow-write`
- add deterministic tests at `tests/bin/analyze-test-flakiness.test.ts` covering CLI args, XML parsing, aggregation, summary rendering, report writing, and exit code behavior

## Validation
- `deno test --allow-read --allow-run --allow-write --coverage=coverage/flakiness tests/bin/analyze-test-flakiness.test.ts`
- `deno lint`
- coverage for `bin/analyze-test-flakiness.ts`: `100.0 / 100.0 / 100.0` (branch/function/line)

## Initial Flakiness Findings
- command: `deno task test-flakiness --runs 3 --command "deno test --allow-read tests/constants.test.ts"`
- observed testcases: 7
- flaky tests detected: 0
