### PR TITLE
Add deterministic changelog synthesizer CLI

### DIFF
--- a/bin/changelog-synth-lib.ts
+++ b/bin/changelog-synth-lib.ts
@@ -1,0 +1,199 @@
+export const SECTION_ORDER = [
+	"Added",
+	"Changed",
+	"Fixed",
+	"Removed",
+	"Tests",
+] as const;
+
+export type ChangelogSection = (typeof SECTION_ORDER)[number];
+
+export type SectionEntries = Record<ChangelogSection, string[]>;
+
+const SECTION_HEADINGS: Record<ChangelogSection, string> = {
+	Added: "## 🚀 Added",
+	Changed: "## 🛠 Changed",
+	Fixed: "## 🐛 Fixed",
+	Removed: "## 💥 Removed",
+	Tests: "## 🧪 Tests",
+};
+
+const REMOVED_KEYWORDS =
+	/\b(remove|removed|removing|drop|dropped|dropping|deprecat(?:e|ed|es|ing|ion))\b/i;
+
+/**
+ * Parses git log output into non-empty commit subjects.
+ */
+export function parseGitLogSubjects(logOutput: string): string[] {
+	return logOutput.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0);
+}
+
+/**
+ * Removes conventional-commit prefixes and normalizes spacing.
+ */
+export function normalizeCommitSubject(subject: string): string {
+	let normalized = subject.trim().replaceAll(/\s+/g, " ");
+	if (normalized.length === 0) {
+		return "";
+	}
+	normalized = normalized.replace(/^[*-]\s+/, "");
+	normalized = normalized.replace(/^([a-z]+)(?:\([^)]+\))?(?:!)?:\s*/i, "");
+	if (normalized.length === 0) {
+		return "";
+	}
+	return normalized.at(0)?.toUpperCase() + normalized.slice(1);
+}
+
+/**
+ * Classifies a commit subject into a Keep a Changelog section.
+ */
+export function classifyCommitSubject(subject: string): ChangelogSection {
+	const trimmed = subject.trim();
+	const lowered = trimmed.toLowerCase();
+
+	if (REMOVED_KEYWORDS.test(lowered)) {
+		return "Removed";
+	}
+
+	const typeMatch = trimmed.match(/^([a-z]+)(?:\([^)]+\))?(?:!)?:/i);
+	const type = typeMatch?.at(1)?.toLowerCase();
+	if (type != null) {
+		if (type === "feat") {
+			return "Added";
+		}
+		if (type === "fix" || type === "hotfix" || type === "bugfix") {
+			return "Fixed";
+		}
+		if (type === "test" || type === "tests") {
+			return "Tests";
+		}
+		return "Changed";
+	}
+
+	if (/\btest(?:s|ing)?\b/i.test(lowered)) {
+		return "Tests";
+	}
+	if (/\bfix(?:es|ed|ing)?\b/i.test(lowered)) {
+		return "Fixed";
+	}
+	if (/\badd(?:s|ed|ing)?\b/i.test(lowered)) {
+		return "Added";
+	}
+	return "Changed";
+}
+
+/**
+ * Creates a deterministic section map with deduplicated entries.
+ */
+export function synthesizeSections(subjects: string[]): SectionEntries {
+	const sections = createEmptySections();
+	const seen = new Set<string>();
+
+	for (const subject of subjects) {
+		if (isIgnoredSubject(subject)) {
+			continue;
+		}
+		const normalized = normalizeCommitSubject(subject);
+		if (normalized.length === 0) {
+			continue;
+		}
+		const section = classifyCommitSubject(subject);
+		const fingerprint = `${section}|${normalized.toLowerCase()}`;
+		if (seen.has(fingerprint)) {
+			continue;
+		}
+		seen.add(fingerprint);
+		sections[section].push(normalized);
+	}
+
+	return sections;
+}
+
+/**
+ * Renders one markdown release block in Keep a Changelog style.
+ */
+export function renderReleaseBlock(
+	version: string,
+	sections: SectionEntries,
+): string {
+	const heading = normalizeVersionHeading(version);
+	const lines: string[] = [`# ${heading}`, ""];
+	let hasEntries = false;
+
+	for (const section of SECTION_ORDER) {
+		const entries = sections[section];
+		if (entries.length === 0) {
+			continue;
+		}
+		hasEntries = true;
+		lines.push(SECTION_HEADINGS[section], "");
+		for (const [index, entry] of entries.entries()) {
+			lines.push(`${index + 1}. ${entry}`);
+		}
+		lines.push("");
+	}
+
+	if (!hasEntries) {
+		lines.push("No notable changes.", "");
+	}
+
+	return `${lines.join("\n").trimEnd()}\n\n`;
+}
+
+/**
+ * Inserts a release block before the first historical release heading.
+ */
+export function prependReleaseBlock(
+	changelogContent: string,
+	releaseBlock: string,
+): string {
+	const normalizedChangelog = changelogContent.replaceAll("\r\n", "\n");
+	const normalizedBlock = `${
+		releaseBlock.replaceAll("\r\n", "\n").trimEnd()
+	}\n\n`;
+	const releaseHeadingIndex = normalizedChangelog.search(/^# v/m);
+
+	if (releaseHeadingIndex === -1) {
+		return `${normalizedChangelog.trimEnd()}\n\n${normalizedBlock}`;
+	}
+
+	const before = normalizedChangelog.slice(0, releaseHeadingIndex).trimEnd();
+	const after = normalizedChangelog.slice(releaseHeadingIndex).trimStart();
+	return `${before}\n\n${normalizedBlock}${after}`;
+}
+
+/**
+ * Formats release versions to match existing changelog headings.
+ */
+export function normalizeVersionHeading(version: string): string {
+	const trimmed = version.trim();
+	if (trimmed.length === 0) {
+		return "Next release";
+	}
+	if (
+		trimmed.toLowerCase() === "next" ||
+		trimmed.toLowerCase() === "next release"
+	) {
+		return "Next release";
+	}
+	if (trimmed.startsWith("v")) {
+		return `v${trimmed.slice(1)}`;
+	}
+	return `v${trimmed}`;
+}
+
+function createEmptySections(): SectionEntries {
+	return {
+		Added: [],
+		Changed: [],
+		Fixed: [],
+		Removed: [],
+		Tests: [],
+	};
+}
+
+function isIgnoredSubject(subject: string): boolean {
+	return /^merge\b/i.test(subject.trim());
+}

--- a/bin/changelog-synth.ts
+++ b/bin/changelog-synth.ts
@@ -1,0 +1,188 @@
+import { dirname, fromFileUrl, join } from "@std/path";
+import {
+	parseGitLogSubjects,
+	prependReleaseBlock,
+	renderReleaseBlock,
+	synthesizeSections,
+} from "./changelog-synth-lib.ts";
+
+interface CliOptions {
+	cwd: string;
+	from: string | null;
+	to: string;
+	version: string;
+	output: string | null;
+	prepend: boolean;
+	dryRun: boolean;
+}
+
+const DEFAULT_CHANGELOG_RELATIVE_PATH = "docs/CHANGELOG.md";
+
+/**
+ * Executes changelog synthesis flow.
+ */
+export async function main(args: string[]): Promise<number> {
+	const projectRoot = defaultProjectRoot();
+	const options = parseArgs(args, projectRoot);
+	const from = options.from ?? await resolveLatestTag(options.cwd);
+	const subjects = await getCommitSubjects(options.cwd, from, options.to);
+	const sections = synthesizeSections(subjects);
+	const releaseBlock = renderReleaseBlock(options.version, sections);
+
+	if (options.prepend) {
+		const changelogPath = options.output ??
+			join(options.cwd, DEFAULT_CHANGELOG_RELATIVE_PATH);
+		const existingContent = await Deno.readTextFile(changelogPath);
+		const updatedContent = prependReleaseBlock(
+			existingContent,
+			releaseBlock,
+		);
+		if (options.dryRun) {
+			await writeStdout(ensureTrailingNewline(updatedContent));
+			return 0;
+		}
+		await Deno.writeTextFile(
+			changelogPath,
+			ensureTrailingNewline(updatedContent),
+		);
+		return 0;
+	}
+
+	if (options.output != null && !options.dryRun) {
+		await Deno.writeTextFile(options.output, releaseBlock);
+		return 0;
+	}
+
+	await writeStdout(releaseBlock);
+	return 0;
+}
+
+/**
+ * Parses CLI args into deterministic options.
+ */
+export function parseArgs(args: string[], projectRoot: string): CliOptions {
+	const parsed: CliOptions = {
+		cwd: projectRoot,
+		from: null,
+		to: "HEAD",
+		version: "Next release",
+		output: null,
+		prepend: false,
+		dryRun: false,
+	};
+
+	for (const arg of args) {
+		if (arg === "--") {
+			continue;
+		}
+		if (arg.startsWith("--from=")) {
+			parsed.from = requireValue(arg, "--from=");
+			continue;
+		}
+		if (arg.startsWith("--to=")) {
+			parsed.to = requireValue(arg, "--to=");
+			continue;
+		}
+		if (arg.startsWith("--version=")) {
+			parsed.version = requireValue(arg, "--version=");
+			continue;
+		}
+		if (arg.startsWith("--output=")) {
+			const outputPath = requireValue(arg, "--output=");
+			parsed.output = resolvePath(parsed.cwd, outputPath);
+			continue;
+		}
+		if (arg.startsWith("--cwd=")) {
+			const cwdValue = requireValue(arg, "--cwd=");
+			parsed.cwd = resolvePath(projectRoot, cwdValue);
+			if (parsed.output != null) {
+				parsed.output = resolvePath(parsed.cwd, parsed.output);
+			}
+			continue;
+		}
+		if (arg === "--prepend") {
+			parsed.prepend = true;
+			continue;
+		}
+		if (arg === "--dry-run") {
+			parsed.dryRun = true;
+			continue;
+		}
+		throw new Error(`Unknown argument: ${arg}`);
+	}
+
+	return parsed;
+}
+
+/**
+ * Resolves latest tag in the target repo.
+ */
+export async function resolveLatestTag(cwd: string): Promise<string | null> {
+	const command = new Deno.Command("git", {
+		args: ["-C", cwd, "describe", "--tags", "--abbrev=0"],
+		stdout: "piped",
+		stderr: "piped",
+	});
+	const { code, stdout } = await command.output();
+	if (code !== 0) {
+		return null;
+	}
+	const tag = new TextDecoder().decode(stdout).trim();
+	return tag.length > 0 ? tag : null;
+}
+
+/**
+ * Reads commit subjects from git log for the provided range.
+ */
+export async function getCommitSubjects(
+	cwd: string,
+	from: string | null,
+	to: string,
+): Promise<string[]> {
+	const range = from == null ? to : `${from}..${to}`;
+	const command = new Deno.Command("git", {
+		args: ["-C", cwd, "log", "--format=%s", range],
+		stdout: "piped",
+		stderr: "piped",
+	});
+	const { code, stdout, stderr } = await command.output();
+	if (code !== 0) {
+		const message = new TextDecoder().decode(stderr).trim();
+		throw new Error(
+			`Failed to read git log for range ${range}: ${message}`,
+		);
+	}
+	return parseGitLogSubjects(new TextDecoder().decode(stdout));
+}
+
+function requireValue(arg: string, prefix: string): string {
+	const value = arg.slice(prefix.length).trim();
+	if (value.length === 0) {
+		throw new Error(`Argument ${prefix.slice(0, -1)} cannot be empty`);
+	}
+	return value;
+}
+
+function resolvePath(basePath: string, value: string): string {
+	if (value.startsWith("/")) {
+		return value;
+	}
+	return join(basePath, value);
+}
+
+function defaultProjectRoot(): string {
+	return join(dirname(fromFileUrl(import.meta.url)), "..");
+}
+
+function ensureTrailingNewline(content: string): string {
+	return content.endsWith("\n") ? content : `${content}\n`;
+}
+
+async function writeStdout(content: string): Promise<void> {
+	await Deno.stdout.write(new TextEncoder().encode(content));
+}
+
+if (import.meta.main) {
+	const exitCode = await main(Deno.args);
+	Deno.exit(exitCode);
+}

--- a/deno.json
+++ b/deno.json
@@ -47,6 +47,7 @@
 		"build-edge": "deno task dev-edge && bash bin/zip-extension.bash edge",
 		"build-safari": "deno task dev-safari && bash bin/zip-extension.bash safari && bash bin/convert-to-safari-app-extension.bash",
 
+		"changelog-synth": "deno --allow-run --allow-read --allow-write bin/changelog-synth.ts",
 		"release": "deno --allow-read --allow-run --allow-env bin/build-releases.ts"
 	},
 	"imports": {

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -30,11 +30,37 @@ Both of these steps are done automatically when you push a commit to a branch wh
   deno task test
   ```
 
-## 4. Commit Message Guidelines
+## 4. Changelog Workflow
+
+For releases, generate a candidate changelog block from commits and then review/edit it:
+
+```bash
+deno task changelog-synth -- --version=2.3.0 --dry-run
+```
+
+To prepend the generated block directly into `docs/CHANGELOG.md`:
+
+```bash
+deno task changelog-synth -- --version=2.3.0 --prepend
+```
+
+Useful options:
+
+- `--from=<git ref>` and `--to=<git ref>` to control the commit range
+- `--output=<path>` to write output to a custom file
+- `--dry-run` to print output without writing files
+
+Expected workflow:
+
+1. Generate the block.
+2. Review and refine wording if needed.
+3. Commit the final changelog update.
+
+## 5. Commit Message Guidelines
 
 We do not follow standards for commit messages as we are much more focused on PRs.
 
-## 5. Pull Request Checklist
+## 6. Pull Request Checklist
 
 - [ ] Tests pass
 - [ ] Linter and formatter run

--- a/tests/bin/changelog-synth.test.ts
+++ b/tests/bin/changelog-synth.test.ts
@@ -1,0 +1,170 @@
+import {
+	assert,
+	assertEquals,
+	assertStringIncludes,
+} from "@std/testing/asserts";
+import {
+	classifyCommitSubject,
+	normalizeCommitSubject,
+	parseGitLogSubjects,
+	prependReleaseBlock,
+	renderReleaseBlock,
+	SECTION_ORDER,
+	synthesizeSections,
+} from "../../bin/changelog-synth-lib.ts";
+import { parseArgs } from "../../bin/changelog-synth.ts";
+
+Deno.test("parseGitLogSubjects ignores empty lines", () => {
+	const parsed = parseGitLogSubjects("feat: a\n\nfix: b\n  \nchore: c\n");
+	assertEquals(parsed, ["feat: a", "fix: b", "chore: c"]);
+});
+
+Deno.test("normalizeCommitSubject strips prefixes and normalizes sentence casing", () => {
+	assertEquals(
+		normalizeCommitSubject("feat(ui): add keyboard shortcuts"),
+		"Add keyboard shortcuts",
+	);
+	assertEquals(
+		normalizeCommitSubject("  * fix: resolve crash "),
+		"Resolve crash",
+	);
+	assertEquals(normalizeCommitSubject(""), "");
+});
+
+Deno.test("classifyCommitSubject maps commit types and removal keywords", () => {
+	assertEquals(classifyCommitSubject("feat: add feature"), "Added");
+	assertEquals(classifyCommitSubject("fix: patch issue"), "Fixed");
+	assertEquals(classifyCommitSubject("test: add coverage"), "Tests");
+	assertEquals(
+		classifyCommitSubject("refactor: improve structure"),
+		"Changed",
+	);
+	assertEquals(
+		classifyCommitSubject("refactor: drop deprecated API"),
+		"Removed",
+	);
+});
+
+Deno.test("synthesizeSections is deterministic and deduplicates repeated entries", () => {
+	const sections = synthesizeSections([
+		"feat(ui): add keyboard shortcuts",
+		"feat: add keyboard shortcuts",
+		"Merge branch 'main' into stag",
+		"fix: resolve startup crash",
+		"chore: tune sync scheduling",
+		"test: add changelog synth coverage",
+		"refactor: deprecate old import pipeline",
+	]);
+
+	assertEquals(sections.Added, ["Add keyboard shortcuts"]);
+	assertEquals(sections.Fixed, ["Resolve startup crash"]);
+	assertEquals(sections.Changed, ["Tune sync scheduling"]);
+	assertEquals(sections.Tests, ["Add changelog synth coverage"]);
+	assertEquals(sections.Removed, ["Deprecate old import pipeline"]);
+});
+
+Deno.test("renderReleaseBlock preserves section order", () => {
+	const block = renderReleaseBlock("2.3.0", {
+		Added: ["Add first"],
+		Changed: ["Change second"],
+		Fixed: ["Fix third"],
+		Removed: ["Remove fourth"],
+		Tests: ["Test fifth"],
+	});
+
+	assertStringIncludes(block, "# v2.3.0");
+
+	let previousIndex = -1;
+	for (const section of SECTION_ORDER) {
+		const heading = {
+			Added: "## 🚀 Added",
+			Changed: "## 🛠 Changed",
+			Fixed: "## 🐛 Fixed",
+			Removed: "## 💥 Removed",
+			Tests: "## 🧪 Tests",
+		}[section];
+		const index = block.indexOf(heading);
+		assert(index > previousIndex);
+		previousIndex = index;
+	}
+});
+
+Deno.test("renderReleaseBlock handles empty ranges", () => {
+	const block = renderReleaseBlock("next", {
+		Added: [],
+		Changed: [],
+		Fixed: [],
+		Removed: [],
+		Tests: [],
+	});
+
+	assertStringIncludes(block, "# Next release");
+	assertStringIncludes(block, "No notable changes.");
+});
+
+Deno.test("prependReleaseBlock inserts after static header and before first release", () => {
+	const existing = [
+		"# CHANGELOG for Again, Why Salesforce",
+		"",
+		"Intro paragraph.",
+		"",
+		"# v2.2.5",
+		"",
+		"## 🛠 Changed",
+		"",
+		"1. Existing item",
+	].join("\n");
+	const block = renderReleaseBlock("2.2.6", {
+		Added: ["Add one"],
+		Changed: [],
+		Fixed: [],
+		Removed: [],
+		Tests: [],
+	});
+
+	const prepended = prependReleaseBlock(existing, block);
+	const firstRelease = prepended.indexOf("# v2.2.5");
+	const inserted = prepended.indexOf("# v2.2.6");
+
+	assert(inserted > -1);
+	assert(inserted < firstRelease);
+	assertStringIncludes(prepended, "# CHANGELOG for Again, Why Salesforce");
+});
+
+Deno.test("parseArgs accepts known options and rejects unknown arguments", () => {
+	const parsed = parseArgs([
+		"--",
+		"--from=v2.2.4",
+		"--to=HEAD",
+		"--version=2.2.5",
+		"--output=docs/new-changelog.md",
+		"--prepend",
+		"--dry-run",
+	], "/repo");
+
+	assertEquals(parsed.from, "v2.2.4");
+	assertEquals(parsed.to, "HEAD");
+	assertEquals(parsed.version, "2.2.5");
+	assertEquals(parsed.output, "/repo/docs/new-changelog.md");
+	assertEquals(parsed.prepend, true);
+	assertEquals(parsed.dryRun, true);
+
+	assertThrowsParse(
+		() => parseArgs(["--unknown=value"], "/repo"),
+		"Unknown argument",
+	);
+	assertThrowsParse(
+		() => parseArgs(["--version="], "/repo"),
+		"cannot be empty",
+	);
+});
+
+function assertThrowsParse(callback: () => unknown, messagePart: string): void {
+	try {
+		callback();
+		throw new Error("Expected parse error");
+	} catch (error) {
+		assert(error instanceof Error);
+		assertStringIncludes(error.message, messagePart);
+	}
+}


### PR DESCRIPTION
## Summary
- add `bin/changelog-synth-lib.ts` with deterministic parsing, normalization, classification, dedupe, rendering, and changelog prepend helpers
- add `bin/changelog-synth.ts` CLI with range args (`--from`, `--to`), output args (`--output`, `--prepend`, `--dry-run`), and default range fallback from latest tag to `HEAD`
- add focused test coverage in `tests/bin/changelog-synth.test.ts`
- wire new task in `deno.json` and document contributor workflow in `docs/CONTRIBUTING.md`

## Assumptions
- implemented in `/home/alfredo/gitRepos/again-why-salesforce` because `/home/alfredo` is not a git repo root
- merge commit subjects are filtered to keep generated release notes clean

## Validation
- `deno lint`
- `deno test -P tests/bin/changelog-synth.test.ts`

## Sample Output
```md
# v2.2.6

## 🛠 Changed

1. Callback management (#197)
2. Use sldsConfirm (#199)

## 🐛 Fixed

1. Fix context menus
```
