### PR TITLE
Add git-based release note drafter

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -22,6 +22,11 @@ jobs:
             - name: Setup repo
               uses: actions/checkout@v4
 
+            - name: Setup Deno
+              uses: denoland/setup-deno@v2
+              with:
+                  deno-version: v2.x
+
             - name: Define variables
               run: |
                 TAG="${GITHUB_REF_NAME}"
@@ -33,28 +38,9 @@ jobs:
                 echo "PRERELEASE=$([ "$TAG_VERSION" != "$MANIFEST_VERSION" ] && echo "true" || echo "false")" >> $GITHUB_ENV
                 # Extract substring before any additional '-' (like '-alpha')
                 PURE_VERSION=${TAG_VERSION%%-*}
-                awk -v ver="v$PURE_VERSION" '
-                  $0 ~ "^# "ver"$" {print_flag=1; next}
-                  $0 ~ "^# v[0-9]+\\.[0-9]+\\.[0-9]+" && print_flag {exit}
-                  print_flag {print}
-                ' "docs/CHANGELOG.md" > release-notes.txt
-                # If release notes are empty, default to last release
-                if [ ! -s release-notes.txt ]; then
-                  awk '
-                    $0 ~ "^# v[0-9]+\\.[0-9]+\\.[0-9]+" {
-                      if (!print_flag) {print_flag=1; next}
-                      else {exit}
-                    }
-                    print_flag {print}
-                  ' "docs/CHANGELOG.md" > release-notes.txt
-                fi
+                deno task draft-release-notes --tag "$PURE_VERSION" --to "HEAD" --output "release-notes.txt" --fallback-file "docs/CHANGELOG.md"
                 echo "RELEASE_NOTES=./release-notes.txt" >> $GITHUB_ENV
                 echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_ENV
-
-            - name: Setup Deno
-              uses: denoland/setup-deno@v2
-              with:
-                  deno-version: v2.x
 
             - name: Build Extension Releases and Publish them
               run: deno task release

--- a/bin/draft-release-notes.ts
+++ b/bin/draft-release-notes.ts
@@ -1,0 +1,249 @@
+import { join } from "@std/path";
+import {
+	extractLatestNotes,
+	extractNotesForTag,
+	groupCommitsBySection,
+	parseGitLogOutput,
+	renderReleaseNotes,
+} from "./release-notes-lib.ts";
+
+interface CliOptions {
+	fromRef: string | null;
+	toRef: string;
+	tag: string | null;
+	outputPath: string;
+	fallbackFilePath: string | null;
+}
+
+interface CliDependencies {
+	executeGit: (args: string[]) => Promise<string>;
+	readTextFile: (path: string) => Promise<string>;
+	writeTextFile: (path: string, content: string) => Promise<void>;
+	cwd: () => string;
+}
+
+const DEFAULT_OUTPUT_PATH = "release-notes.txt";
+
+/**
+ * CLI entrypoint.
+ */
+export async function main(
+	args: string[],
+	deps: CliDependencies = defaultDependencies(),
+): Promise<number> {
+	const options = parseArgs(args, deps.cwd());
+	const fromRef = options.fromRef ?? await resolveDefaultFromRef(
+		options.toRef,
+		deps.executeGit,
+	);
+	const rawLog = await readCommitLog(fromRef, options.toRef, deps.executeGit);
+	const commits = parseGitLogOutput(rawLog);
+	let notes = "";
+
+	if (commits.length > 0) {
+		const groupedNotes = groupCommitsBySection(commits);
+		notes = renderReleaseNotes(groupedNotes);
+	}
+
+	if (!notes && options.fallbackFilePath != null) {
+		const changelog = await deps.readTextFile(options.fallbackFilePath);
+		notes = options.tag != null
+			? extractNotesForTag(changelog, options.tag)
+			: "";
+		if (!notes) {
+			notes = extractLatestNotes(changelog);
+		}
+	}
+
+	const normalizedNotes = notes.trim() || "- No notable changes.";
+	await deps.writeTextFile(options.outputPath, `${normalizedNotes}\n`);
+	return 0;
+}
+
+/**
+ * Parses command-line options.
+ */
+export function parseArgs(args: string[], cwd: string): CliOptions {
+	const parsed: CliOptions = {
+		fromRef: null,
+		toRef: "HEAD",
+		tag: null,
+		outputPath: join(cwd, DEFAULT_OUTPUT_PATH),
+		fallbackFilePath: join(cwd, "docs", "CHANGELOG.md"),
+	};
+
+	let index = 0;
+	while (index < args.length) {
+		const arg = args[index];
+		if (arg === "--help") {
+			throw new Error(helpText());
+		}
+		if (arg.startsWith("--from=")) {
+			parsed.fromRef = arg.slice("--from=".length);
+			index += 1;
+			continue;
+		}
+		if (arg === "--from") {
+			const value = args[index + 1];
+			if (!value) {
+				throw new Error("Missing value for --from");
+			}
+			parsed.fromRef = value;
+			index += 2;
+			continue;
+		}
+		if (arg.startsWith("--to=")) {
+			parsed.toRef = arg.slice("--to=".length);
+			index += 1;
+			continue;
+		}
+		if (arg === "--to") {
+			const value = args[index + 1];
+			if (!value) {
+				throw new Error("Missing value for --to");
+			}
+			parsed.toRef = value;
+			index += 2;
+			continue;
+		}
+		if (arg.startsWith("--tag=")) {
+			parsed.tag = arg.slice("--tag=".length);
+			index += 1;
+			continue;
+		}
+		if (arg === "--tag") {
+			const value = args[index + 1];
+			if (!value) {
+				throw new Error("Missing value for --tag");
+			}
+			parsed.tag = value;
+			index += 2;
+			continue;
+		}
+		if (arg.startsWith("--output=")) {
+			parsed.outputPath = resolvePath(cwd, arg.slice("--output=".length));
+			index += 1;
+			continue;
+		}
+		if (arg === "--output") {
+			const value = args[index + 1];
+			if (!value) {
+				throw new Error("Missing value for --output");
+			}
+			parsed.outputPath = resolvePath(cwd, value);
+			index += 2;
+			continue;
+		}
+		if (arg.startsWith("--fallback-file=")) {
+			const value = arg.slice("--fallback-file=".length);
+			parsed.fallbackFilePath = value ? resolvePath(cwd, value) : null;
+			index += 1;
+			continue;
+		}
+		if (arg === "--fallback-file") {
+			const value = args[index + 1];
+			if (value == null) {
+				throw new Error("Missing value for --fallback-file");
+			}
+			parsed.fallbackFilePath = value ? resolvePath(cwd, value) : null;
+			index += 2;
+			continue;
+		}
+		throw new Error(`Unknown argument: ${arg}`);
+	}
+
+	return parsed;
+}
+
+/**
+ * Resolves the commit reference that precedes `toRef`.
+ */
+export async function resolveDefaultFromRef(
+	toRef: string,
+	executeGit: (args: string[]) => Promise<string>,
+): Promise<string | null> {
+	try {
+		const previousTag = await executeGit([
+			"describe",
+			"--tags",
+			"--abbrev=0",
+			`${toRef}^`,
+		]);
+		return previousTag.trim() || null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Reads commit log entries for the selected range.
+ */
+export async function readCommitLog(
+	fromRef: string | null,
+	toRef: string,
+	executeGit: (args: string[]) => Promise<string>,
+): Promise<string> {
+	const range = fromRef != null ? `${fromRef}..${toRef}` : toRef;
+	return await executeGit([
+		"log",
+		"--reverse",
+		"--pretty=format:%H%x1f%s%x1f%b%x1e",
+		range,
+	]);
+}
+
+function resolvePath(cwd: string, pathValue: string): string {
+	if (pathValue.startsWith("/")) {
+		return pathValue;
+	}
+	return join(cwd, pathValue);
+}
+
+function defaultDependencies(): CliDependencies {
+	return {
+		executeGit: async (args: string[]): Promise<string> => {
+			const command = new Deno.Command("git", {
+				args,
+				stdout: "piped",
+				stderr: "piped",
+			});
+			const { code, stdout, stderr } = await command.output();
+			if (code !== 0) {
+				throw new Error(new TextDecoder().decode(stderr).trim());
+			}
+			return new TextDecoder().decode(stdout);
+		},
+		readTextFile: (path: string): Promise<string> =>
+			Deno.readTextFile(path),
+		writeTextFile: (path: string, content: string): Promise<void> =>
+			Deno.writeTextFile(path, content),
+		cwd: () => Deno.cwd(),
+	};
+}
+
+function helpText(): string {
+	return [
+		"Draft release notes from git history.",
+		"",
+		"Flags:",
+		"  --from <ref>            Start reference (optional; defaults to previous tag).",
+		"  --to <ref>              End reference (default: HEAD).",
+		"  --tag <version>         Tag used for changelog fallback extraction.",
+		"  --output <file>         Output file path (default: release-notes.txt).",
+		"  --fallback-file <file>  Changelog file for fallback extraction (default: docs/CHANGELOG.md).",
+	].join("\n");
+}
+
+if (import.meta.main) {
+	try {
+		const exitCode = await main(Deno.args);
+		Deno.exit(exitCode);
+	} catch (error) {
+		if (error instanceof Error) {
+			console.error(error.message);
+		} else {
+			console.error(error);
+		}
+		Deno.exit(1);
+	}
+}

--- a/bin/release-notes-lib.ts
+++ b/bin/release-notes-lib.ts
@@ -1,0 +1,235 @@
+export const RELEASE_SECTIONS = [
+	"Added",
+	"Changed",
+	"Fixed",
+	"Removed",
+	"Security",
+	"Other",
+] as const;
+
+export type ReleaseSection = typeof RELEASE_SECTIONS[number];
+
+export interface CommitRecord {
+	hash: string;
+	subject: string;
+	body: string;
+}
+
+export interface SectionedNotes {
+	Added: string[];
+	Changed: string[];
+	Fixed: string[];
+	Removed: string[];
+	Security: string[];
+	Other: string[];
+}
+
+const PREFIX_TO_SECTION: Record<string, ReleaseSection> = {
+	add: "Added",
+	chore: "Changed",
+	change: "Changed",
+	ci: "Changed",
+	docs: "Changed",
+	feat: "Added",
+	fix: "Fixed",
+	hotfix: "Fixed",
+	perf: "Changed",
+	refactor: "Changed",
+	remove: "Removed",
+	revert: "Changed",
+	sec: "Security",
+	security: "Security",
+	test: "Other",
+};
+
+const SECURITY_KEYWORDS =
+	/\b(security|cve-\d{4}-\d+|vulnerab|xss|csrf|injection|auth(?:entication|orization)?)\b/i;
+const REMOVED_KEYWORDS =
+	/\b(remove|removed|delete|deleted|drop|dropped|deprecat(?:e|ed|ion)|sunset)\b/i;
+const FIXED_KEYWORDS =
+	/\b(fix|fixed|bug|hotfix|patch|resolve|resolved|resolves)\b/i;
+const ADDED_KEYWORDS =
+	/\b(add|added|introduce|introduced|create|created|implement|implemented|new)\b/i;
+const CHANGED_KEYWORDS =
+	/\b(change|changed|update|updated|refactor|refactored|improve|improved|optimi[sz]e|optimized|optimised|performance|cleanup)\b/i;
+
+/**
+ * Parses raw `git log` output produced with unit/record separators.
+ */
+export function parseGitLogOutput(rawOutput: string): CommitRecord[] {
+	if (!rawOutput.trim()) {
+		return [];
+	}
+
+	const records: CommitRecord[] = [];
+	for (const chunk of rawOutput.split("\x1e")) {
+		const trimmed = chunk.trim();
+		if (!trimmed) {
+			continue;
+		}
+		const [hash = "", subject = "", body = ""] = trimmed.split("\x1f");
+		records.push({
+			hash: hash.trim(),
+			subject: subject.trim(),
+			body: body.trim(),
+		});
+	}
+	return records;
+}
+
+/**
+ * Classifies commit messages into release-note sections.
+ */
+export function classifyCommitMessage(message: string): ReleaseSection {
+	const normalized = message.trim();
+	const conventionalPrefix = normalized.match(
+		/^([a-z]+)(?:\([^)]+\))?(?:!)?:\s*/i,
+	);
+	if (conventionalPrefix != null) {
+		const prefix = conventionalPrefix[1].toLowerCase();
+		const mapped = PREFIX_TO_SECTION[prefix];
+		if (mapped != null) {
+			return mapped;
+		}
+	}
+
+	if (SECURITY_KEYWORDS.test(normalized)) {
+		return "Security";
+	}
+	if (REMOVED_KEYWORDS.test(normalized)) {
+		return "Removed";
+	}
+	if (FIXED_KEYWORDS.test(normalized)) {
+		return "Fixed";
+	}
+	if (ADDED_KEYWORDS.test(normalized)) {
+		return "Added";
+	}
+	if (CHANGED_KEYWORDS.test(normalized)) {
+		return "Changed";
+	}
+	return "Other";
+}
+
+/**
+ * Normalizes a commit title into a readable release-note bullet.
+ */
+export function normalizeCommitSubject(subject: string): string {
+	const trimmed = subject.trim();
+	if (!trimmed) {
+		return "(no subject)";
+	}
+	const stripped = trimmed.replace(
+		/^[a-z]+(?:\([^)]+\))?(?:!)?:\s*/i,
+		"",
+	);
+	return stripped || trimmed;
+}
+
+/**
+ * Groups commits by section while preserving input order.
+ */
+export function groupCommitsBySection(commits: CommitRecord[]): SectionedNotes {
+	const grouped = emptySectionedNotes();
+	for (const commit of commits) {
+		const message = `${commit.subject}\n${commit.body}`;
+		const section = classifyCommitMessage(message);
+		grouped[section].push(normalizeCommitSubject(commit.subject));
+	}
+	return grouped;
+}
+
+/**
+ * Renders markdown release notes in a deterministic section order.
+ */
+export function renderReleaseNotes(notes: SectionedNotes): string {
+	const lines: string[] = [];
+	for (const section of RELEASE_SECTIONS) {
+		const entries = notes[section];
+		if (entries.length === 0) {
+			continue;
+		}
+		lines.push(`## ${section}`);
+		lines.push("");
+		for (const entry of entries) {
+			lines.push(`- ${entry}`);
+		}
+		lines.push("");
+	}
+	return lines.join("\n").trim();
+}
+
+/**
+ * Extracts release notes for a specific tag from changelog markdown.
+ */
+export function extractNotesForTag(
+	changelogMarkdown: string,
+	tag: string,
+): string {
+	const targetTag = normalizeTag(tag);
+	const lines = changelogMarkdown.split("\n");
+	let collecting = false;
+	const collected: string[] = [];
+	for (const line of lines) {
+		if (!collecting && line.trim() === `# ${targetTag}`) {
+			collecting = true;
+			continue;
+		}
+		if (collecting && /^# v\d+\.\d+\.\d+/.test(line.trim())) {
+			break;
+		}
+		if (collecting) {
+			collected.push(line);
+		}
+	}
+	return collected.join("\n").trim();
+}
+
+/**
+ * Extracts notes from the latest changelog release section.
+ */
+export function extractLatestNotes(changelogMarkdown: string): string {
+	const lines = changelogMarkdown.split("\n");
+	let collecting = false;
+	const collected: string[] = [];
+	for (const line of lines) {
+		const trimmed = line.trim();
+		if (/^# v\d+\.\d+\.\d+/.test(trimmed)) {
+			if (!collecting) {
+				collecting = true;
+				continue;
+			}
+			break;
+		}
+		if (collecting) {
+			collected.push(line);
+		}
+	}
+	return collected.join("\n").trim();
+}
+
+/**
+ * Creates an empty section map with stable keys.
+ */
+export function emptySectionedNotes(): SectionedNotes {
+	return {
+		Added: [],
+		Changed: [],
+		Fixed: [],
+		Removed: [],
+		Security: [],
+		Other: [],
+	};
+}
+
+/**
+ * Normalizes version strings (`2.3.1-alpha`, `v2.3.1`) to `v2.3.1`.
+ */
+export function normalizeTag(tag: string): string {
+	const noRefPrefix = tag.replace(/^refs\/tags\//, "").trim();
+	const [baseVersion] = noRefPrefix.split("-");
+	if (!baseVersion.startsWith("v")) {
+		return `v${baseVersion}`;
+	}
+	return baseVersion;
+}

--- a/deno.json
+++ b/deno.json
@@ -47,6 +47,7 @@
 		"build-edge": "deno task dev-edge && bash bin/zip-extension.bash edge",
 		"build-safari": "deno task dev-safari && bash bin/zip-extension.bash safari && bash bin/convert-to-safari-app-extension.bash",
 
+		"draft-release-notes": "deno --allow-read --allow-write --allow-run bin/draft-release-notes.ts",
 		"release": "deno --allow-read --allow-run --allow-env bin/build-releases.ts"
 	},
 	"imports": {

--- a/tests/bin/draft-release-notes.test.ts
+++ b/tests/bin/draft-release-notes.test.ts
@@ -1,0 +1,143 @@
+import { assert, assertEquals, assertThrows } from "@std/testing/asserts";
+import { join } from "@std/path";
+import {
+	main,
+	parseArgs,
+	resolveDefaultFromRef,
+} from "../../bin/draft-release-notes.ts";
+
+Deno.test("parseArgs supports equals and spaced flags", () => {
+	const parsed = parseArgs([
+		"--from=v1.0.0",
+		"--to",
+		"HEAD~1",
+		"--tag",
+		"v2.0.0",
+		"--output=out/notes.txt",
+		"--fallback-file",
+		"docs/CHANGELOG.md",
+	], "/repo");
+
+	assertEquals(parsed.fromRef, "v1.0.0");
+	assertEquals(parsed.toRef, "HEAD~1");
+	assertEquals(parsed.tag, "v2.0.0");
+	assertEquals(parsed.outputPath, "/repo/out/notes.txt");
+	assertEquals(parsed.fallbackFilePath, "/repo/docs/CHANGELOG.md");
+});
+
+Deno.test("parseArgs rejects unknown flags", () => {
+	assertThrows(
+		() => parseArgs(["--unknown"], "/repo"),
+		Error,
+		"Unknown argument",
+	);
+});
+
+Deno.test("main uses changelog fallback when commit range is empty", async () => {
+	const writes = new Map<string, string>();
+	const exitCode = await main([
+		"--from=v1.0.0",
+		"--to=HEAD",
+		"--tag=2.0.0",
+		"--output=release-notes.txt",
+	], {
+		executeGit: (args: string[]): Promise<string> => {
+			assertEquals(args[0], "log");
+			return Promise.resolve("");
+		},
+		readTextFile: (): Promise<string> =>
+			Promise.resolve([
+				"# CHANGELOG",
+				"",
+				"# v2.0.0",
+				"",
+				"## Fixed",
+				"- bug",
+			].join("\n")),
+		writeTextFile: (path: string, content: string): Promise<void> => {
+			writes.set(path, content);
+			return Promise.resolve();
+		},
+		cwd: () => "/repo",
+	});
+
+	assertEquals(exitCode, 0);
+	assertEquals(writes.get("/repo/release-notes.txt"), "## Fixed\n- bug\n");
+});
+
+Deno.test("main handles empty range without fallback by writing default note", async () => {
+	const writes = new Map<string, string>();
+	await main([
+		"--from=HEAD",
+		"--to=HEAD",
+		"--output=notes.md",
+		"--fallback-file=",
+	], {
+		executeGit: (): Promise<string> => Promise.resolve(""),
+		readTextFile: (): Promise<string> => Promise.resolve(""),
+		writeTextFile: (path: string, content: string): Promise<void> => {
+			writes.set(path, content);
+			return Promise.resolve();
+		},
+		cwd: () => "/repo",
+	});
+
+	assertEquals(writes.get("/repo/notes.md"), "- No notable changes.\n");
+});
+
+Deno.test("main renders stable section ordering for git-derived notes", async () => {
+	const writes = new Map<string, string>();
+	const rawLog = [
+		"h1\x1ffix: patch crash\x1f\x1e",
+		"h2\x1ffeat: add importer\x1f\x1e",
+		"h3\x1fsecurity: harden auth\x1f\x1e",
+	].join("");
+	await main([
+		"--from=v1.0.0",
+		"--to=HEAD",
+		"--output=ordered.md",
+	], {
+		executeGit: (): Promise<string> => Promise.resolve(rawLog),
+		readTextFile: (): Promise<string> => Promise.resolve(""),
+		writeTextFile: (path: string, content: string): Promise<void> => {
+			writes.set(path, content);
+			return Promise.resolve();
+		},
+		cwd: () => "/repo",
+	});
+
+	const output = writes.get("/repo/ordered.md");
+	assert(output != null);
+	assertEquals(
+		output,
+		[
+			"## Added",
+			"",
+			"- add importer",
+			"",
+			"## Fixed",
+			"",
+			"- patch crash",
+			"",
+			"## Security",
+			"",
+			"- harden auth",
+			"",
+		].join("\n"),
+	);
+});
+
+Deno.test("resolveDefaultFromRef returns null when describe fails", async () => {
+	const resolved = await resolveDefaultFromRef(
+		"HEAD",
+		() => Promise.reject(new Error("no tag")),
+	);
+	assertEquals(resolved, null);
+});
+
+Deno.test("parseArgs default paths are rooted at cwd", () => {
+	const cwd = "/repo";
+	const parsed = parseArgs([], cwd);
+	assertEquals(parsed.outputPath, join(cwd, "release-notes.txt"));
+	assertEquals(parsed.fallbackFilePath, join(cwd, "docs", "CHANGELOG.md"));
+});

--- a/tests/bin/release-notes-lib.test.ts
+++ b/tests/bin/release-notes-lib.test.ts
@@ -1,0 +1,108 @@
+import { assertEquals } from "@std/testing/asserts";
+import {
+	classifyCommitMessage,
+	extractLatestNotes,
+	extractNotesForTag,
+	groupCommitsBySection,
+	normalizeCommitSubject,
+	normalizeTag,
+	parseGitLogOutput,
+	renderReleaseNotes,
+} from "../../bin/release-notes-lib.ts";
+
+Deno.test("parseGitLogOutput parses records using separators", () => {
+	const raw = [
+		"a1\x1ffeat: add menu\x1fdetails\x1e",
+		"b2\x1ffix(parser): handle empty\x1f\x1e",
+	].join("");
+	assertEquals(parseGitLogOutput(raw), [
+		{ hash: "a1", subject: "feat: add menu", body: "details" },
+		{ hash: "b2", subject: "fix(parser): handle empty", body: "" },
+	]);
+	assertEquals(parseGitLogOutput("\n\t"), []);
+});
+
+Deno.test("classifyCommitMessage maps prefixes and keywords", () => {
+	assertEquals(classifyCommitMessage("feat: add support"), "Added");
+	assertEquals(classifyCommitMessage("fix(ui): button crash"), "Fixed");
+	assertEquals(classifyCommitMessage("security: patch XSS"), "Security");
+	assertEquals(classifyCommitMessage("delete unused handler"), "Removed");
+	assertEquals(
+		classifyCommitMessage("refactor: improve internals"),
+		"Changed",
+	);
+	assertEquals(classifyCommitMessage("bump deps"), "Other");
+});
+
+Deno.test("groupCommitsBySection and renderReleaseNotes keep deterministic order", () => {
+	const grouped = groupCommitsBySection([
+		{ hash: "1", subject: "fix: close edge case", body: "" },
+		{ hash: "2", subject: "feat(core): add endpoint", body: "" },
+		{ hash: "3", subject: "docs: update docs", body: "" },
+		{ hash: "4", subject: "remove dead config", body: "" },
+		{ hash: "5", subject: "security hardening", body: "" },
+		{ hash: "6", subject: "misc notes", body: "" },
+	]);
+	const markdown = renderReleaseNotes(grouped);
+	assertEquals(
+		markdown,
+		[
+			"## Added",
+			"",
+			"- add endpoint",
+			"",
+			"## Changed",
+			"",
+			"- update docs",
+			"",
+			"## Fixed",
+			"",
+			"- close edge case",
+			"",
+			"## Removed",
+			"",
+			"- remove dead config",
+			"",
+			"## Security",
+			"",
+			"- security hardening",
+			"",
+			"## Other",
+			"",
+			"- misc notes",
+		].join("\n"),
+	);
+});
+
+Deno.test("normalizeCommitSubject strips conventional prefix and handles empty", () => {
+	assertEquals(
+		normalizeCommitSubject("feat(parser)!: add safety"),
+		"add safety",
+	);
+	assertEquals(normalizeCommitSubject(""), "(no subject)");
+});
+
+Deno.test("changelog extraction returns tagged section and latest fallback", () => {
+	const changelog = [
+		"# CHANGELOG",
+		"",
+		"# v2.0.0",
+		"",
+		"## Added",
+		"- major release",
+		"",
+		"# v1.9.0",
+		"",
+		"## Fixed",
+		"- bugfix",
+	].join("\n");
+
+	assertEquals(
+		extractNotesForTag(changelog, "2.0.0"),
+		"## Added\n- major release",
+	);
+	assertEquals(extractNotesForTag(changelog, "v8.8.8"), "");
+	assertEquals(extractLatestNotes(changelog), "## Added\n- major release");
+	assertEquals(normalizeTag("refs/tags/v2.0.0-beta"), "v2.0.0");
+	assertEquals(normalizeTag("2.0.0"), "v2.0.0");
+});


### PR DESCRIPTION
## Summary
- add a dedicated release-note drafting library and CLI (`bin/release-notes-lib.ts`, `bin/draft-release-notes.ts`) that builds markdown notes from git commits
- keep the release env contract unchanged by continuing to export `RELEASE_NOTES`, `TRIGGERING_TAG`, `TAG_VERSION`, and `PRERELEASE`
- replace inline changelog parsing in `.github/workflows/create-releases.yml` with `deno task draft-release-notes`, preserving changelog fallback behavior for empty commit ranges
- add `draft-release-notes` task in `deno.json`
- add unit and command-level tests for parsing/classification/rendering, CLI arguments, fallback behavior, and output ordering

## Assumptions
- repo root: `/home/alfredo/gitRepos/again-why-salesforce`
- release base branch: `stag`

## Test Evidence
- `deno task lint`
- `deno task test-bin`
- `deno task test`
