### PR TITLE
feat: draft release notes from git history

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -1,9 +1,9 @@
 name: Create all Releases
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
+    push:
+        tags:
+            - "v*.*.*"
 
 permissions:
     contents: write
@@ -21,40 +21,27 @@ jobs:
         steps:
             - name: Setup repo
               uses: actions/checkout@v4
-
-            - name: Define variables
-              run: |
-                TAG="${GITHUB_REF_NAME}"
-                echo "TRIGGERING_TAG=$TAG" >> $GITHUB_ENV
-                # Extract substring after 'v'
-                TAG_VERSION=${TAG##*v}
-                # Get version from manifest
-                MANIFEST_VERSION=$(awk '/"version":/ { match($0, /"[0-9.]+"/); print substr($0, RSTART+1, RLENGTH-2) }' src/manifest/template-manifest.json)
-                echo "PRERELEASE=$([ "$TAG_VERSION" != "$MANIFEST_VERSION" ] && echo "true" || echo "false")" >> $GITHUB_ENV
-                # Extract substring before any additional '-' (like '-alpha')
-                PURE_VERSION=${TAG_VERSION%%-*}
-                awk -v ver="v$PURE_VERSION" '
-                  $0 ~ "^# "ver"$" {print_flag=1; next}
-                  $0 ~ "^# v[0-9]+\\.[0-9]+\\.[0-9]+" && print_flag {exit}
-                  print_flag {print}
-                ' "docs/CHANGELOG.md" > release-notes.txt
-                # If release notes are empty, default to last release
-                if [ ! -s release-notes.txt ]; then
-                  awk '
-                    $0 ~ "^# v[0-9]+\\.[0-9]+\\.[0-9]+" {
-                      if (!print_flag) {print_flag=1; next}
-                      else {exit}
-                    }
-                    print_flag {print}
-                  ' "docs/CHANGELOG.md" > release-notes.txt
-                fi
-                echo "RELEASE_NOTES=./release-notes.txt" >> $GITHUB_ENV
-                echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_ENV
+              with:
+                  fetch-depth: 0
+                  fetch-tags: true
 
             - name: Setup Deno
               uses: denoland/setup-deno@v2
               with:
                   deno-version: v2.x
+
+            - name: Define variables
+              run: |
+                  TAG="${GITHUB_REF_NAME}"
+                  echo "TRIGGERING_TAG=$TAG" >> $GITHUB_ENV
+                  # Extract substring after 'v'
+                  TAG_VERSION=${TAG##*v}
+                  # Get version from manifest
+                  MANIFEST_VERSION=$(awk '/"version":/ { match($0, /"[0-9.]+"/); print substr($0, RSTART+1, RLENGTH-2) }' src/manifest/template-manifest.json)
+                  echo "PRERELEASE=$([ "$TAG_VERSION" != "$MANIFEST_VERSION" ] && echo "true" || echo "false")" >> $GITHUB_ENV
+                  deno task draft-release-notes --tag="$TAG" --to="$TAG" --output=release-notes.txt --fallback-file=docs/CHANGELOG.md
+                  echo "RELEASE_NOTES=./release-notes.txt" >> $GITHUB_ENV
+                  echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_ENV
 
             - name: Build Extension Releases and Publish them
               run: deno task release

--- a/bin/draft-release-notes.ts
+++ b/bin/draft-release-notes.ts
@@ -1,0 +1,136 @@
+import { join } from "@std/path";
+import {
+	extractChangelogNotes,
+	parseCommitLog,
+	readCommitLog,
+	renderReleaseNotes,
+	resolveDefaultFromRef,
+	type RunGitCommand,
+	runGitCommand,
+} from "./release-notes-lib.ts";
+
+interface CliOptions {
+	fromRef: string | null;
+	toRef: string;
+	tag: string | null;
+	outputFile: string;
+	fallbackFile: string;
+}
+
+interface CliDependencies {
+	cwd: () => string;
+	readTextFile: (path: string) => Promise<string>;
+	writeTextFile: (path: string, content: string) => Promise<void>;
+	runGit: RunGitCommand;
+}
+
+const DEFAULT_OUTPUT = "release-notes.txt";
+const DEFAULT_FALLBACK = join("docs", "CHANGELOG.md");
+
+/**
+ * Drafts markdown release notes from git history and changelog fallback.
+ */
+export async function main(
+	args: string[],
+	dependencies: Partial<CliDependencies> = {},
+): Promise<number> {
+	const deps: CliDependencies = {
+		cwd: dependencies.cwd ?? (() => Deno.cwd()),
+		readTextFile: dependencies.readTextFile ?? Deno.readTextFile,
+		writeTextFile: dependencies.writeTextFile ?? Deno.writeTextFile,
+		runGit: dependencies.runGit ?? runGitCommand,
+	};
+
+	const options = parseArgs(args, deps.cwd());
+	const fromRef = options.fromRef ??
+		await resolveDefaultFromRef(options.toRef, options.tag, deps.runGit);
+	const commitLog = await readCommitLog(options.toRef, fromRef, deps.runGit);
+	const notesFromGit = renderReleaseNotes(parseCommitLog(commitLog));
+
+	let finalNotes = notesFromGit.trim();
+	if (finalNotes.length === 0) {
+		const fallbackContent = await deps.readTextFile(options.fallbackFile);
+		finalNotes = extractChangelogNotes(fallbackContent, options.tag);
+	}
+	if (finalNotes.length === 0) {
+		finalNotes = "No release notes available.";
+	}
+
+	await deps.writeTextFile(options.outputFile, `${finalNotes}\n`);
+	return 0;
+}
+
+/**
+ * Parses command-line arguments.
+ */
+export function parseArgs(args: string[], projectRoot: string): CliOptions {
+	const parsed: CliOptions = {
+		fromRef: null,
+		toRef: "HEAD",
+		tag: null,
+		outputFile: join(projectRoot, DEFAULT_OUTPUT),
+		fallbackFile: join(projectRoot, DEFAULT_FALLBACK),
+	};
+
+	for (const arg of args) {
+		if (arg.startsWith("--from=")) {
+			parsed.fromRef = arg.slice("--from=".length).trim();
+			continue;
+		}
+		if (arg.startsWith("--to=")) {
+			parsed.toRef = arg.slice("--to=".length).trim();
+			continue;
+		}
+		if (arg.startsWith("--tag=")) {
+			parsed.tag = arg.slice("--tag=".length).trim();
+			continue;
+		}
+		if (arg.startsWith("--output=")) {
+			parsed.outputFile = resolvePath(
+				projectRoot,
+				arg.slice("--output=".length).trim(),
+			);
+			continue;
+		}
+		if (arg.startsWith("--fallback-file=")) {
+			parsed.fallbackFile = resolvePath(
+				projectRoot,
+				arg.slice("--fallback-file=".length).trim(),
+			);
+			continue;
+		}
+		throw new Error(`Unknown argument: ${arg}`);
+	}
+
+	if (parsed.toRef.length === 0) {
+		throw new Error("--to cannot be empty");
+	}
+	if (parsed.fromRef != null && parsed.fromRef.length === 0) {
+		parsed.fromRef = null;
+	}
+	if (parsed.tag != null && parsed.tag.length === 0) {
+		parsed.tag = null;
+	}
+	return parsed;
+}
+
+function resolvePath(projectRoot: string, value: string): string {
+	if (value.startsWith("/")) {
+		return value;
+	}
+	return join(projectRoot, value);
+}
+
+if (import.meta.main) {
+	try {
+		const exitCode = await main(Deno.args);
+		Deno.exit(exitCode);
+	} catch (error) {
+		if (error instanceof Error) {
+			console.error(error.message);
+		} else {
+			console.error("Failed to draft release notes.");
+		}
+		Deno.exit(1);
+	}
+}

--- a/bin/release-notes-lib.ts
+++ b/bin/release-notes-lib.ts
@@ -1,0 +1,339 @@
+export type ReleaseSection =
+	| "Added"
+	| "Changed"
+	| "Fixed"
+	| "Removed"
+	| "Security"
+	| "Other";
+
+export interface CommitEntry {
+	hash: string;
+	subject: string;
+	body: string;
+}
+
+export interface GitCommandResult {
+	success: boolean;
+	stdout: string;
+	stderr: string;
+}
+
+export type RunGitCommand = (
+	args: string[],
+) => Promise<GitCommandResult>;
+
+export const COMMIT_RECORD_SEPARATOR = "\x1e";
+export const COMMIT_FIELD_SEPARATOR = "\x1f";
+export const GIT_LOG_FORMAT =
+	`%H${COMMIT_FIELD_SEPARATOR}%s${COMMIT_FIELD_SEPARATOR}%b${COMMIT_RECORD_SEPARATOR}`;
+
+const VERSION_HEADING_PATTERN = /^# v\d+\.\d+\.\d+(?:[-.][0-9A-Za-z.-]+)?$/;
+const CONVENTIONAL_TYPE_PATTERN = /^([a-z]+)(?:\([^)]*\))?!?:\s*/i;
+const SECURITY_PATTERN =
+	/\b(security|cve|xss|csrf|vulnerability|vulnerab|injection|auth(?:entication|orization)?)\b/i;
+const FIX_PATTERN = /\b(fix|bug|patch|resolve|regression|hotfix)\b/i;
+const REMOVE_PATTERN = /\b(remove|deleted?|drop|deprecat|cleanup)\b/i;
+const ADD_PATTERN = /\b(add|introduce|create|implement|new)\b/i;
+const CHANGE_PATTERN =
+	/\b(change|update|improve|refactor|rename|bump|adjust)\b/i;
+
+const SECTION_ORDER: ReleaseSection[] = [
+	"Added",
+	"Changed",
+	"Fixed",
+	"Removed",
+	"Security",
+	"Other",
+];
+
+export class GitCommandError extends Error {
+	args: string[];
+
+	constructor(args: string[], stderr: string) {
+		const message = stderr.length > 0
+			? `git ${args.join(" ")} failed: ${stderr}`
+			: `git ${args.join(" ")} failed`;
+		super(message);
+		this.name = "GitCommandError";
+		this.args = args;
+	}
+}
+
+/**
+ * Executes a git command and returns decoded output.
+ */
+export async function runGitCommand(args: string[]): Promise<GitCommandResult> {
+	const command = new Deno.Command("git", {
+		args,
+		stdout: "piped",
+		stderr: "piped",
+	});
+	const output = await command.output();
+	const decoder = new TextDecoder();
+	return {
+		success: output.code === 0,
+		stdout: decoder.decode(output.stdout).trim(),
+		stderr: decoder.decode(output.stderr).trim(),
+	};
+}
+
+/**
+ * Resolves the previous tag reachable from `toRef`.
+ */
+export async function resolveDefaultFromRef(
+	toRef: string,
+	tag: string | null,
+	runGit: RunGitCommand = runGitCommand,
+): Promise<string | null> {
+	const tagsAtRefArgs = ["tag", "--points-at", toRef];
+	const tagsAtRef = await runGit(tagsAtRefArgs);
+	if (!tagsAtRef.success) {
+		throw new GitCommandError(tagsAtRefArgs, tagsAtRef.stderr);
+	}
+	const excludedTags = new Set<string>();
+	if (tag != null && tag.length > 0) {
+		excludedTags.add(tag);
+	}
+	if (tagsAtRef.stdout.length > 0) {
+		for (const row of tagsAtRef.stdout.split("\n")) {
+			const value = row.trim();
+			if (value.length > 0) {
+				excludedTags.add(value);
+			}
+		}
+	}
+
+	const mergedTagsArgs = [
+		"for-each-ref",
+		"--merged",
+		toRef,
+		"--sort=-creatordate",
+		"--format=%(refname:short)",
+		"refs/tags",
+	];
+	const mergedTags = await runGit(mergedTagsArgs);
+	if (!mergedTags.success) {
+		throw new GitCommandError(mergedTagsArgs, mergedTags.stderr);
+	}
+	if (mergedTags.stdout.length === 0) {
+		return null;
+	}
+
+	for (const row of mergedTags.stdout.split("\n")) {
+		const candidate = row.trim();
+		if (candidate.length === 0 || excludedTags.has(candidate)) {
+			continue;
+		}
+		return candidate;
+	}
+	return null;
+}
+
+/**
+ * Reads git commit history for a range.
+ */
+export async function readCommitLog(
+	toRef: string,
+	fromRef: string | null,
+	runGit: RunGitCommand = runGitCommand,
+): Promise<string> {
+	const range = fromRef == null ? toRef : `${fromRef}..${toRef}`;
+	const args = [
+		"log",
+		"--format",
+		GIT_LOG_FORMAT,
+		range,
+	];
+	const result = await runGit(args);
+	if (!result.success) {
+		throw new GitCommandError(args, result.stderr);
+	}
+	return result.stdout;
+}
+
+/**
+ * Parses serialized git log output into commit entries.
+ */
+export function parseCommitLog(rawLog: string): CommitEntry[] {
+	if (rawLog.trim().length === 0) {
+		return [];
+	}
+	const entries: CommitEntry[] = [];
+	for (const record of rawLog.split(COMMIT_RECORD_SEPARATOR)) {
+		if (record.trim().length === 0) {
+			continue;
+		}
+		const fields = record.split(COMMIT_FIELD_SEPARATOR);
+		entries.push({
+			hash: fields[0]?.trim() ?? "",
+			subject: fields[1]?.trim() ?? "",
+			body: fields.slice(2).join(COMMIT_FIELD_SEPARATOR).trim(),
+		});
+	}
+	return entries.filter((entry) => entry.subject.length > 0);
+}
+
+/**
+ * Classifies a commit into a release-note section.
+ */
+export function classifyCommit(entry: CommitEntry): ReleaseSection {
+	const combined = `${entry.subject}\n${entry.body}`.toLowerCase();
+	const conventionalType = extractConventionalType(entry.subject);
+
+	if (
+		conventionalType === "security" || SECURITY_PATTERN.test(combined)
+	) {
+		return "Security";
+	}
+	if (
+		conventionalType === "fix" || conventionalType === "bugfix" ||
+		conventionalType === "hotfix" || FIX_PATTERN.test(combined)
+	) {
+		return "Fixed";
+	}
+	if (
+		conventionalType === "remove" || conventionalType === "delete" ||
+		conventionalType === "deprecate" || REMOVE_PATTERN.test(combined)
+	) {
+		return "Removed";
+	}
+	if (
+		conventionalType === "feat" || conventionalType === "add" ||
+		ADD_PATTERN.test(combined)
+	) {
+		return "Added";
+	}
+	if (
+		conventionalType === "change" || conventionalType === "chore" ||
+		conventionalType === "refactor" || conventionalType === "perf" ||
+		conventionalType === "build" || conventionalType === "ci" ||
+		conventionalType === "docs" || conventionalType === "style" ||
+		conventionalType === "test" || CHANGE_PATTERN.test(combined)
+	) {
+		return "Changed";
+	}
+	return "Other";
+}
+
+/**
+ * Renders markdown release notes from commit entries.
+ */
+export function renderReleaseNotes(commits: CommitEntry[]): string {
+	const grouped = new Map<ReleaseSection, string[]>();
+	for (const section of SECTION_ORDER) {
+		grouped.set(section, []);
+	}
+
+	for (const commit of commits) {
+		const section = classifyCommit(commit);
+		grouped.get(section)?.push(formatCommitLine(commit));
+	}
+
+	const chunks: string[] = [];
+	for (const section of SECTION_ORDER) {
+		const lines = grouped.get(section) ?? [];
+		if (lines.length === 0) {
+			continue;
+		}
+		chunks.push(`## ${section}\n\n${lines.join("\n")}`);
+	}
+
+	return chunks.join("\n\n").trim();
+}
+
+/**
+ * Extracts changelog notes for a tag section, with fallback to latest section.
+ */
+export function extractChangelogNotes(
+	changelogContent: string,
+	tag: string | null,
+): string {
+	const lines = changelogContent.split("\n");
+	if (tag != null && tag.length > 0) {
+		const normalizedVersion = normalizeVersion(tag);
+		const targetedHeading = `# v${normalizedVersion}`;
+		const targeted = collectSection(
+			lines,
+			(line) => line.trim() === targetedHeading,
+		);
+		if (targeted.length > 0) {
+			return targeted.join("\n").trim();
+		}
+	}
+
+	const latest = collectSection(
+		lines,
+		(line) => VERSION_HEADING_PATTERN.test(line.trim()),
+	);
+	return latest.join("\n").trim();
+}
+
+/**
+ * Removes common conventional-commit prefixes from a title.
+ */
+export function sanitizeSubject(subject: string): string {
+	const trimmed = subject.trim();
+	if (trimmed.length === 0) {
+		return "Untitled commit";
+	}
+	return trimmed.replace(CONVENTIONAL_TYPE_PATTERN, "");
+}
+
+function extractConventionalType(subject: string): string | null {
+	const match = subject.trim().match(/^([a-z]+)(?:\([^)]*\))?!?:/i);
+	if (match == null) {
+		return null;
+	}
+	return match[1].toLowerCase();
+}
+
+function formatCommitLine(commit: CommitEntry): string {
+	const safeHash = commit.hash.slice(0, 7);
+	return `- ${sanitizeSubject(commit.subject)} (${safeHash})`;
+}
+
+function normalizeVersion(tag: string): string {
+	let value = tag.trim();
+	if (value.startsWith("refs/tags/")) {
+		value = value.slice("refs/tags/".length);
+	}
+	if (value.startsWith("v")) {
+		value = value.slice(1);
+	}
+	const separatorIndex = value.indexOf("-");
+	if (separatorIndex >= 0) {
+		return value.slice(0, separatorIndex);
+	}
+	return value;
+}
+
+function collectSection(
+	lines: string[],
+	startMatcher: (line: string) => boolean,
+): string[] {
+	const startIndex = lines.findIndex(startMatcher);
+	if (startIndex < 0) {
+		return [];
+	}
+	const content: string[] = [];
+	for (let index = startIndex + 1; index < lines.length; index += 1) {
+		const line = lines[index];
+		if (VERSION_HEADING_PATTERN.test(line.trim())) {
+			break;
+		}
+		content.push(line);
+	}
+	return trimSurroundingEmptyLines(content);
+}
+
+function trimSurroundingEmptyLines(lines: string[]): string[] {
+	let start = 0;
+	while (start < lines.length && lines[start].trim().length === 0) {
+		start += 1;
+	}
+	let end = lines.length;
+	while (end > start && lines[end - 1].trim().length === 0) {
+		end -= 1;
+	}
+	return lines.slice(start, end);
+}

--- a/deno.json
+++ b/deno.json
@@ -34,6 +34,7 @@
 		"locale-check": "deno --allow-read --allow-write bin/find-invalid-variables.ts && deno --allow-read --allow-write bin/missing-locales.ts",
 		"locales": "deno task locale-check && deno task sort",
 		"audit-logging": "deno run --allow-read --allow-write bin/audit-logging.ts",
+		"draft-release-notes": "deno run --allow-read --allow-write --allow-run bin/draft-release-notes.ts",
 		"bundle": "deno run -A bin/build.ts",
 		"checks": "deno task fmt && deno task lint && deno task test && deno task locales && deno task dev-firefox",
 

--- a/tests/bin/draft-release-notes.test.ts
+++ b/tests/bin/draft-release-notes.test.ts
@@ -1,0 +1,226 @@
+import { assertEquals, assertRejects, assertThrows } from "@std/testing/asserts";
+import { main, parseArgs } from "../../bin/draft-release-notes.ts";
+import type {
+	GitCommandResult,
+	RunGitCommand,
+} from "../../bin/release-notes-lib.ts";
+
+Deno.test("parseArgs parses defaults and explicit options", () => {
+	const parsed = parseArgs([
+		"--from=v1.0.0",
+		"--to=v1.1.0",
+		"--tag=v1.1.0",
+		"--output=tmp/release-notes.txt",
+		"--fallback-file=docs/CHANGELOG.md",
+	], "/repo");
+
+	assertEquals(parsed.fromRef, "v1.0.0");
+	assertEquals(parsed.toRef, "v1.1.0");
+	assertEquals(parsed.tag, "v1.1.0");
+	assertEquals(parsed.outputFile, "/repo/tmp/release-notes.txt");
+	assertEquals(parsed.fallbackFile, "/repo/docs/CHANGELOG.md");
+
+	const defaults = parseArgs([], "/repo");
+	assertEquals(defaults.toRef, "HEAD");
+	assertEquals(defaults.fromRef, null);
+	assertEquals(defaults.outputFile, "/repo/release-notes.txt");
+	assertEquals(defaults.fallbackFile, "/repo/docs/CHANGELOG.md");
+});
+
+Deno.test("parseArgs rejects unknown arguments", () => {
+	assertThrows(
+		() => parseArgs(["--unknown=1"], "/repo"),
+		Error,
+		"Unknown argument",
+	);
+});
+
+Deno.test("main writes notes derived from git commits", async () => {
+	let outputPath = "";
+	let outputContent = "";
+	const calls: string[][] = [];
+
+	const runGit: RunGitCommand = (
+		args: string[],
+	): Promise<GitCommandResult> => {
+		calls.push(args);
+		if (args[0] === "tag") {
+			return Promise.resolve({
+				success: true,
+				stdout: "v2.0.0",
+				stderr: "",
+			});
+		}
+		if (args[0] === "for-each-ref") {
+			return Promise.resolve({
+				success: true,
+				stdout: "v2.0.0\nv1.9.0",
+				stderr: "",
+			});
+		}
+		if (args[0] === "log") {
+			return Promise.resolve({
+				success: true,
+				stdout: [
+					"abc1234\x1ffeat: add release drafter\x1f\x1e",
+					"def5678\x1ffix: resolve range bug\x1f\x1e",
+				].join(""),
+				stderr: "",
+			});
+		}
+		return Promise.resolve({
+			success: false,
+			stdout: "",
+			stderr: "unexpected",
+		});
+	};
+
+	const code = await main([
+		"--to=v2.0.0",
+		"--tag=v2.0.0",
+		"--output=release-notes.txt",
+	], {
+		cwd: () => "/repo",
+		runGit,
+		readTextFile: () => Promise.resolve("unused"),
+		writeTextFile: (path: string, content: string): Promise<void> => {
+			outputPath = path;
+			outputContent = content;
+			return Promise.resolve();
+		},
+	});
+
+	assertEquals(code, 0);
+	assertEquals(outputPath, "/repo/release-notes.txt");
+	assertEquals(
+		outputContent,
+		[
+			"## Added",
+			"",
+			"- add release drafter (abc1234)",
+			"",
+			"## Fixed",
+			"",
+			"- resolve range bug (def5678)",
+			"",
+		].join("\n"),
+	);
+	assertEquals(calls.some((entry) => entry.includes("v1.9.0..v2.0.0")), true);
+});
+
+Deno.test("main falls back to changelog when commit range is empty", async () => {
+	let outputContent = "";
+	let fallbackReadCount = 0;
+	const runGit: RunGitCommand = (
+		args: string[],
+	): Promise<GitCommandResult> => {
+		if (args[0] === "tag") {
+			return Promise.resolve({
+				success: true,
+				stdout: "v2.1.0",
+				stderr: "",
+			});
+		}
+		if (args[0] === "for-each-ref") {
+			return Promise.resolve({
+				success: true,
+				stdout: "v2.1.0\nv2.0.0",
+				stderr: "",
+			});
+		}
+		if (args[0] === "log") {
+			return Promise.resolve({ success: true, stdout: "", stderr: "" });
+		}
+		return Promise.resolve({
+			success: false,
+			stdout: "",
+			stderr: "unexpected",
+		});
+	};
+
+	await main([
+		"--to=v2.1.0",
+		"--tag=v2.1.0",
+	], {
+		cwd: () => "/repo",
+		runGit,
+		readTextFile: (): Promise<string> => {
+			fallbackReadCount += 1;
+			return Promise.resolve([
+				"# CHANGELOG",
+				"",
+				"# v2.1.0",
+				"",
+				"## Changed",
+				"",
+				"- fallback section",
+			].join("\n"));
+		},
+		writeTextFile: (
+			_path: string,
+			content: string,
+		): Promise<void> => {
+			outputContent = content;
+			return Promise.resolve();
+		},
+	});
+
+	assertEquals(fallbackReadCount, 1);
+	assertEquals(
+		outputContent,
+		["## Changed", "", "- fallback section", ""].join("\n"),
+	);
+});
+
+Deno.test("main throws when git history lookup fails", async () => {
+	let fallbackReadCount = 0;
+	const runGit: RunGitCommand = (
+		args: string[],
+	): Promise<GitCommandResult> => {
+		if (args[0] === "tag") {
+			return Promise.resolve({
+				success: true,
+				stdout: "v2.1.0",
+				stderr: "",
+			});
+		}
+		if (args[0] === "for-each-ref") {
+			return Promise.resolve({
+				success: true,
+				stdout: "v2.1.0\nv2.0.0",
+				stderr: "",
+			});
+		}
+		if (args[0] === "log") {
+			return Promise.resolve({
+				success: false,
+				stdout: "",
+				stderr: "fatal: bad revision",
+			});
+		}
+		return Promise.resolve({
+			success: false,
+			stdout: "",
+			stderr: "unexpected",
+		});
+	};
+
+	await assertRejects(
+		() =>
+			main([
+				"--to=v2.1.0",
+				"--tag=v2.1.0",
+			], {
+				cwd: () => "/repo",
+				runGit,
+				readTextFile: (): Promise<string> => {
+					fallbackReadCount += 1;
+					return Promise.resolve("# CHANGELOG");
+				},
+				writeTextFile: (): Promise<void> => Promise.resolve(),
+			}),
+		Error,
+		"fatal: bad revision",
+	);
+	assertEquals(fallbackReadCount, 0);
+});

--- a/tests/bin/draft-release-notes.test.ts
+++ b/tests/bin/draft-release-notes.test.ts
@@ -1,4 +1,8 @@
-import { assertEquals, assertRejects, assertThrows } from "@std/testing/asserts";
+import {
+	assertEquals,
+	assertRejects,
+	assertThrows,
+} from "@std/testing/asserts";
 import { main, parseArgs } from "../../bin/draft-release-notes.ts";
 import type {
 	GitCommandResult,

--- a/tests/bin/release-notes-lib.test.ts
+++ b/tests/bin/release-notes-lib.test.ts
@@ -1,0 +1,211 @@
+import { assertEquals, assertRejects } from "@std/testing/asserts";
+import {
+	classifyCommit,
+	COMMIT_FIELD_SEPARATOR,
+	COMMIT_RECORD_SEPARATOR,
+	extractChangelogNotes,
+	type GitCommandResult,
+	parseCommitLog,
+	readCommitLog,
+	renderReleaseNotes,
+	resolveDefaultFromRef,
+	type RunGitCommand,
+} from "../../bin/release-notes-lib.ts";
+
+Deno.test("parseCommitLog parses serialized records", () => {
+	const raw = [
+		`aaaaaaaa${COMMIT_FIELD_SEPARATOR}feat: add parser${COMMIT_FIELD_SEPARATOR}body line${COMMIT_RECORD_SEPARATOR}`,
+		`bbbbbbbb${COMMIT_FIELD_SEPARATOR}fix(ui): resolve bug${COMMIT_FIELD_SEPARATOR}${COMMIT_RECORD_SEPARATOR}`,
+	].join("");
+	const parsed = parseCommitLog(raw);
+	assertEquals(parsed.length, 2);
+	assertEquals(parsed[0].hash, "aaaaaaaa");
+	assertEquals(parsed[0].subject, "feat: add parser");
+	assertEquals(parsed[0].body, "body line");
+	assertEquals(parsed[1].subject, "fix(ui): resolve bug");
+});
+
+Deno.test("classifyCommit maps prefixes and keywords into canonical sections", () => {
+	assertEquals(
+		classifyCommit({ hash: "1", subject: "feat: add api", body: "" }),
+		"Added",
+	);
+	assertEquals(
+		classifyCommit({ hash: "2", subject: "fix: resolve crash", body: "" }),
+		"Fixed",
+	);
+	assertEquals(
+		classifyCommit({ hash: "3", subject: "chore: update deps", body: "" }),
+		"Changed",
+	);
+	assertEquals(
+		classifyCommit({
+			hash: "4",
+			subject: "refactor: remove legacy flow",
+			body: "",
+		}),
+		"Removed",
+	);
+	assertEquals(
+		classifyCommit({
+			hash: "5",
+			subject: "docs: harden auth against xss",
+			body: "",
+		}),
+		"Security",
+	);
+	assertEquals(
+		classifyCommit({ hash: "6", subject: "merge branch alpha", body: "" }),
+		"Other",
+	);
+});
+
+Deno.test("renderReleaseNotes keeps deterministic section ordering", () => {
+	const notes = renderReleaseNotes([
+		{ hash: "aaaaaaa", subject: "fix: patch bug", body: "" },
+		{ hash: "bbbbbbb", subject: "feat: add drafter", body: "" },
+		{ hash: "ccccccc", subject: "chore: update workflow", body: "" },
+		{ hash: "ddddddd", subject: "docs: mitigate xss", body: "" },
+	]);
+	assertEquals(
+		notes,
+		[
+			"## Added",
+			"",
+			"- add drafter (bbbbbbb)",
+			"",
+			"## Changed",
+			"",
+			"- update workflow (ccccccc)",
+			"",
+			"## Fixed",
+			"",
+			"- patch bug (aaaaaaa)",
+			"",
+			"## Security",
+			"",
+			"- mitigate xss (ddddddd)",
+		].join("\n"),
+	);
+});
+
+Deno.test("extractChangelogNotes keeps tag-targeted extraction with latest fallback", () => {
+	const changelog = [
+		"# CHANGELOG",
+		"",
+		"# v2.0.0",
+		"",
+		"## Changed",
+		"",
+		"- current notes",
+		"",
+		"# v1.9.0",
+		"",
+		"## Fixed",
+		"",
+		"- older notes",
+	].join("\n");
+	assertEquals(
+		extractChangelogNotes(changelog, "v2.0.0-alpha"),
+		["## Changed", "", "- current notes"].join("\n"),
+	);
+	assertEquals(
+		extractChangelogNotes(changelog, "v9.9.9"),
+		["## Changed", "", "- current notes"].join("\n"),
+	);
+});
+
+Deno.test("resolveDefaultFromRef excludes current tag and picks previous merged tag", async () => {
+	const calls: string[][] = [];
+	const runGit: RunGitCommand = (
+		args: string[],
+	): Promise<GitCommandResult> => {
+		calls.push(args);
+		if (args[0] === "tag") {
+			return Promise.resolve({
+				success: true,
+				stdout: "v2.0.0\nlatest",
+				stderr: "",
+			});
+		}
+		if (args[0] === "for-each-ref") {
+			return Promise.resolve({
+				success: true,
+				stdout: "latest\nv2.0.0\nv1.9.0\nv1.8.0",
+				stderr: "",
+			});
+		}
+		return Promise.resolve({
+			success: false,
+			stdout: "",
+			stderr: "unexpected",
+		});
+	};
+
+	const resolved = await resolveDefaultFromRef("v2.0.0", "v2.0.0", runGit);
+	assertEquals(resolved, "v1.9.0");
+	assertEquals(calls[0], ["tag", "--points-at", "v2.0.0"]);
+	assertEquals(calls[1][0], "for-each-ref");
+});
+
+Deno.test("readCommitLog supports explicit ranges and single-ref fallback", async () => {
+	const calls: string[][] = [];
+	const runGit: RunGitCommand = (
+		args: string[],
+	): Promise<GitCommandResult> => {
+		calls.push(args);
+		return Promise.resolve({
+			success: true,
+			stdout: "serialized",
+			stderr: "",
+		});
+	};
+
+	const rangeLog = await readCommitLog("HEAD", "v1.0.0", runGit);
+	const headLog = await readCommitLog("HEAD", null, runGit);
+	assertEquals(rangeLog, "serialized");
+	assertEquals(headLog, "serialized");
+	assertEquals(calls[0].at(-1), "v1.0.0..HEAD");
+	assertEquals(calls[1].at(-1), "HEAD");
+});
+
+Deno.test("readCommitLog throws when git log fails", async () => {
+	const runGit: RunGitCommand = (): Promise<GitCommandResult> => {
+		return Promise.resolve({
+			success: false,
+			stdout: "",
+			stderr: "fatal: bad revision",
+		});
+	};
+
+	await assertRejects(
+		() => readCommitLog("HEAD", "v1.0.0", runGit),
+		Error,
+		"fatal: bad revision",
+	);
+});
+
+Deno.test("resolveDefaultFromRef throws when git metadata commands fail", async () => {
+	const runGit: RunGitCommand = (
+		args: string[],
+	): Promise<GitCommandResult> => {
+		if (args[0] === "tag") {
+			return Promise.resolve({
+				success: false,
+				stdout: "",
+				stderr: "fatal: malformed object name",
+			});
+		}
+		return Promise.resolve({
+			success: true,
+			stdout: "",
+			stderr: "",
+		});
+	};
+
+	await assertRejects(
+		() => resolveDefaultFromRef("badref", null, runGit),
+		Error,
+		"fatal: malformed object name",
+	);
+});


### PR DESCRIPTION
## Summary
- add a dedicated release-note drafter CLI (`bin/draft-release-notes.ts`) and reusable library (`bin/release-notes-lib.ts`) to derive notes from git commits
- preserve existing release env contract by still exporting `RELEASE_NOTES`, `TRIGGERING_TAG`, `TAG_VERSION`, and `PRERELEASE`
- replace inline workflow changelog parsing with `deno task draft-release-notes`
- fetch full git/tag history in release workflow (`fetch-depth: 0`, `fetch-tags: true`)
- keep changelog fallback only when commit range is empty, but fail fast when git commands fail so CI does not silently publish incorrect notes

## Assumptions
- repository root is `/home/alfredo/gitRepos/again-why-salesforce`
- release comparison base is `stag`

## Testing
- `deno task lint`
- `deno task test-bin`
- `deno task test`
